### PR TITLE
Frontend rate limiting

### DIFF
--- a/communityvi-frontend/src/lib/components/player/Player.svelte
+++ b/communityvi-frontend/src/lib/components/player/Player.svelte
@@ -84,7 +84,6 @@
 	}
 </script>
 
-<!-- FIXME: Need debouncing! -->
 <!-- svelte-ignore a11y-media-has-caption -->
 <section id="player" class:is-hidden={$videoUrl === undefined}>
 	<video controls src={$videoUrl ?? ''} bind:this={player} />

--- a/communityvi-frontend/src/lib/utils/rate_limiter.ts
+++ b/communityvi-frontend/src/lib/utils/rate_limiter.ts
@@ -1,0 +1,39 @@
+export default class RateLimiter {
+	private readonly intervalInMilliseconds: number;
+
+	private timeOfLastCall: DOMTimeStamp | DOMHighResTimeStamp;
+	private pendingTimeout?: NodeJS.Timeout;
+
+	constructor(intervalInMilliseconds: number) {
+		this.intervalInMilliseconds = intervalInMilliseconds;
+		this.timeOfLastCall = performance.now() - intervalInMilliseconds;
+	}
+
+	call(call: () => void): void {
+		const callAndUpdateTimeOfLastCall = () => {
+			call();
+			this.timeOfLastCall = performance.now();
+		};
+
+		if (performance.now() - this.timeOfLastCall >= this.intervalInMilliseconds) {
+			this.replacePendingTimeout();
+			callAndUpdateTimeOfLastCall();
+			return;
+		}
+
+		const timeout = setTimeout(callAndUpdateTimeOfLastCall, this.intervalInMilliseconds);
+		this.replacePendingTimeout(timeout);
+	}
+
+	reset(): void {
+		this.replacePendingTimeout();
+	}
+
+	private replacePendingTimeout(newTimeout?: NodeJS.Timeout) {
+		if (this.pendingTimeout !== undefined) {
+			clearTimeout(this.pendingTimeout);
+		}
+
+		this.pendingTimeout = newTimeout;
+	}
+}


### PR DESCRIPTION
Currently when seeking, the frontend creates skip events really fast, which triggers the server rate limit and eventually leads to the client being kicked from the server. This can easily be prevented by doing rate limiting on the player in the frontend.