### PR TITLE
Playback position adjustment threshold

### DIFF
--- a/communityvi-frontend/src/lib/components/player/player_coordinator.ts
+++ b/communityvi-frontend/src/lib/components/player/player_coordinator.ts
@@ -74,7 +74,10 @@ export default class PlayerCoordinator {
 		this.rateLimiter.reset();
 
 		if (playbackState instanceof PlayingPlaybackState) {
-			this.setPlayerPosition(performance.now() - playbackState.localStartTimeInMilliseconds);
+			const proposedCurrentTime = performance.now() - playbackState.localStartTimeInMilliseconds;
+			if (Math.abs(this.player.currentTime - (proposedCurrentTime / 1000)) > 1) {
+				this.setPlayerPosition(proposedCurrentTime);
+			}
 			if (this.player.paused) {
 				await this.player.play();
 			}

--- a/communityvi-frontend/src/lib/components/player/player_coordinator.ts
+++ b/communityvi-frontend/src/lib/components/player/player_coordinator.ts
@@ -14,17 +14,26 @@ export default class PlayerCoordinator {
 	private readonly playCallback: PlayCallback;
 	private readonly pauseCallback: PauseCallback;
 
+	private readonly playbackPositionAdjustmentThresholdMilliseconds: number;
+
 	static async forPlayerWithInitialState(
 		player: HTMLMediaElement | null | undefined,
 		initialPlaybackState: PlayingPlaybackState | PausedPlaybackState | undefined,
 		playCallback: PlayCallback,
 		pauseCallback: PauseCallback,
+		playbackPositionAdjustmentThresholdMilliseconds = 1000,
 	): Promise<PlayerCoordinator | undefined> {
 		if (!player || initialPlaybackState === undefined) {
 			return undefined;
 		}
 
-		const playerStateManager = new PlayerCoordinator(player, initialPlaybackState, playCallback, pauseCallback);
+		const playerStateManager = new PlayerCoordinator(
+			player,
+			initialPlaybackState,
+			playCallback,
+			pauseCallback,
+			playbackPositionAdjustmentThresholdMilliseconds,
+		);
 
 		// Ensure the playback position is synchronized after reconnect
 		await playerStateManager.syncPlaybackPosition(initialPlaybackState);
@@ -37,6 +46,7 @@ export default class PlayerCoordinator {
 		initialPlaybackState: PlayingPlaybackState | PausedPlaybackState,
 		playCallback: PlayCallback,
 		pauseCallback: PauseCallback,
+		playbackPositionAdjustmentThresholdMilliseconds: number,
 	) {
 		this.player = player;
 
@@ -49,6 +59,8 @@ export default class PlayerCoordinator {
 
 		this.playCallback = playCallback;
 		this.pauseCallback = pauseCallback;
+
+		this.playbackPositionAdjustmentThresholdMilliseconds = playbackPositionAdjustmentThresholdMilliseconds;
 	}
 
 	async setPlaybackState(playbackState?: PlayingPlaybackState | PausedPlaybackState): Promise<void> {
@@ -74,10 +86,11 @@ export default class PlayerCoordinator {
 		this.rateLimiter.reset();
 
 		if (playbackState instanceof PlayingPlaybackState) {
-			const proposedCurrentTime = performance.now() - playbackState.localStartTimeInMilliseconds;
-			if (Math.abs(this.player.currentTime - proposedCurrentTime / 1000) > 1) {
-				this.setPlayerPosition(proposedCurrentTime);
+			const position = performance.now() - playbackState.localStartTimeInMilliseconds;
+			if (this.positionAdjustmentExceedsThreshold(position)) {
+				this.setPlayerPosition(position);
 			}
+
 			if (this.player.paused) {
 				await this.player.play();
 			}
@@ -89,6 +102,12 @@ export default class PlayerCoordinator {
 		if (!this.player.paused) {
 			this.player.pause();
 		}
+	}
+
+	private positionAdjustmentExceedsThreshold(milliseconds: number): boolean {
+		return (
+			Math.abs(this.player.currentTime * 1000 - milliseconds) > this.playbackPositionAdjustmentThresholdMilliseconds
+		);
 	}
 
 	private setPlayerPosition(milliseconds: number) {

--- a/communityvi-frontend/src/lib/components/player/player_coordinator.ts
+++ b/communityvi-frontend/src/lib/components/player/player_coordinator.ts
@@ -75,7 +75,7 @@ export default class PlayerCoordinator {
 
 		if (playbackState instanceof PlayingPlaybackState) {
 			const proposedCurrentTime = performance.now() - playbackState.localStartTimeInMilliseconds;
-			if (Math.abs(this.player.currentTime - (proposedCurrentTime / 1000)) > 1) {
+			if (Math.abs(this.player.currentTime - proposedCurrentTime / 1000) > 1) {
 				this.setPlayerPosition(proposedCurrentTime);
 			}
 			if (this.player.paused) {

--- a/communityvi-frontend/src/lib/components/player/player_coordinator.ts
+++ b/communityvi-frontend/src/lib/components/player/player_coordinator.ts
@@ -87,12 +87,14 @@ export default class PlayerCoordinator {
 
 		if (playbackState instanceof PlayingPlaybackState) {
 			const position = performance.now() - playbackState.localStartTimeInMilliseconds;
-			if (this.positionAdjustmentExceedsThreshold(position)) {
+			if (this.player.paused) {
 				this.setPlayerPosition(position);
+				await this.player.play();
+				return;
 			}
 
-			if (this.player.paused) {
-				await this.player.play();
+			if (this.positionAdjustmentExceedsThreshold(position)) {
+				this.setPlayerPosition(position);
 			}
 
 			return;
@@ -106,7 +108,7 @@ export default class PlayerCoordinator {
 
 	private positionAdjustmentExceedsThreshold(milliseconds: number): boolean {
 		return (
-			Math.abs(this.player.currentTime * 1000 - milliseconds) > this.playbackPositionAdjustmentThresholdMilliseconds
+			Math.abs(this.player.currentTime * 1000 - milliseconds) >= this.playbackPositionAdjustmentThresholdMilliseconds
 		);
 	}
 

--- a/communityvi-frontend/tests/components/player_coordinator.spec.ts
+++ b/communityvi-frontend/tests/components/player_coordinator.spec.ts
@@ -1,0 +1,84 @@
+import {PausedPlaybackState} from '$lib/client/model';
+import PlayerCoordinator from '$lib/components/player/player_coordinator';
+import {mock} from 'jest-mock-extended';
+
+describe('The PlayerCoordinator', () => {
+	describe('forPlayerWithInitialSate factory', () => {
+		it('constructs a PlayerCoordinator', async () => {
+			const player = mock<HTMLMediaElement>();
+			const initialPlaybackState = new PausedPlaybackState(0);
+			const callback = jest.fn();
+
+			const playerCoordinator = await PlayerCoordinator.forPlayerWithInitialState(
+				player,
+				initialPlaybackState,
+				callback,
+				callback,
+			);
+
+			expect(playerCoordinator).toBeInstanceOf(PlayerCoordinator);
+		});
+
+		it('ignores undefined player', async () => {
+			const player = undefined;
+			const initialPlaybackState = new PausedPlaybackState(0);
+			const callback = jest.fn();
+
+			const playerCoordinator = await PlayerCoordinator.forPlayerWithInitialState(
+				player,
+				initialPlaybackState,
+				callback,
+				callback,
+			);
+
+			expect(playerCoordinator).toBeUndefined();
+		});
+
+		it('ignores null player', async () => {
+			const player = null;
+			const initialPlaybackState = new PausedPlaybackState(0);
+			const callback = jest.fn();
+
+			const playerCoordinator = await PlayerCoordinator.forPlayerWithInitialState(
+				player,
+				initialPlaybackState,
+				callback,
+				callback,
+			);
+
+			expect(playerCoordinator).toBeUndefined();
+		});
+
+		it('ignores undefined initial playback state', async () => {
+			const player = mock<HTMLMediaElement>();
+			const initialPlaybackState = undefined;
+			const callback = jest.fn();
+
+			const playerCoordinator = await PlayerCoordinator.forPlayerWithInitialState(
+				player,
+				initialPlaybackState,
+				callback,
+				callback,
+			);
+
+			expect(playerCoordinator).toBeUndefined();
+		});
+
+		it('syncs the player with the initial playback state', async () => {
+			const player = mock<HTMLMediaElement>({
+				currentTime: 42,
+				paused: false,
+			});
+			const pausePosition = 1337;
+			const initialPlaybackState = new PausedPlaybackState(pausePosition);
+			const callback = jest.fn();
+
+			await PlayerCoordinator.forPlayerWithInitialState(player, initialPlaybackState, callback, callback);
+
+			expect(player.currentTime).toBe(pausePosition / 1000);
+			expect(player.pause).toHaveBeenCalledTimes(1);
+		});
+	});
+});
+
+export {};

--- a/communityvi-frontend/tests/components/player_coordinator.spec.ts
+++ b/communityvi-frontend/tests/components/player_coordinator.spec.ts
@@ -1,6 +1,7 @@
-import {PausedPlaybackState} from '$lib/client/model';
+import {PausedPlaybackState, PlayingPlaybackState} from '$lib/client/model';
 import PlayerCoordinator from '$lib/components/player/player_coordinator';
 import {mock} from 'jest-mock-extended';
+import TimeMock from '../client/helper/time_mock';
 
 describe('The PlayerCoordinator', () => {
 	describe('forPlayerWithInitialSate factory', () => {
@@ -79,6 +80,128 @@ describe('The PlayerCoordinator', () => {
 			expect(player.pause).toHaveBeenCalledTimes(1);
 		});
 	});
+
+	describe('updating the player based on a new playback state from the server', () => {
+		it('pauses a playing player', async () => {
+			const player = mock<HTMLMediaElement>({
+				paused: false,
+			});
+			const initialPlaybackState = new PlayingPlaybackState(0);
+			const playerCoordinator = await PlayerCoordinator.forPlayerWithInitialState(
+				player,
+				initialPlaybackState,
+				jest.fn(),
+				jest.fn(),
+			);
+
+			playerCoordinator?.setPlaybackState(new PausedPlaybackState(42));
+
+			expect(player.pause).toHaveBeenCalledTimes(1);
+			expect(player.currentTime).toBe(0.042);
+		});
+
+		it('skips an already paused player', async () => {
+			const initialPosition = 42;
+			const player = mock<HTMLMediaElement>({
+				paused: true,
+				currentTime: initialPosition / 1000,
+			});
+			const initialPlaybackState = new PausedPlaybackState(initialPosition);
+			const playerCoordinator = await PlayerCoordinator.forPlayerWithInitialState(
+				player,
+				initialPlaybackState,
+				jest.fn(),
+				jest.fn(),
+			);
+
+			playerCoordinator?.setPlaybackState(new PausedPlaybackState(1_337));
+
+			expect(player.pause).not.toHaveBeenCalled();
+			expect(player.play).not.toHaveBeenCalled();
+			expect(player.currentTime).toBe(1.337);
+		});
+
+		it('starts a paused player', async () => {
+			const initialPerformanceNow = 1000;
+
+			await TimeMock.run(async () => {
+				const player = mock<HTMLMediaElement>({
+					paused: true,
+				});
+				const initialPlaybackState = new PausedPlaybackState(0);
+				const playerCoordinator = await PlayerCoordinator.forPlayerWithInitialState(
+					player,
+					initialPlaybackState,
+					jest.fn(),
+					jest.fn(),
+				);
+
+				playerCoordinator?.setPlaybackState(new PlayingPlaybackState(42));
+
+				expect(player.play).toHaveBeenCalledTimes(1);
+				expect(player.currentTime).toBe((initialPerformanceNow - 42) / 1000);
+			}, initialPerformanceNow);
+		});
+
+		it('skips an already playing player if new position is above threshold', async () => {
+			const initialPerformanceNow = 1000;
+
+			await TimeMock.run(async () => {
+				const player = mock<HTMLMediaElement>({
+					paused: false,
+					currentTime: 0,
+				});
+				const initialPlaybackState = new PlayingPlaybackState(initialPerformanceNow);
+				const thresholdMilliseconds = 1000;
+				const playerCoordinator = await PlayerCoordinator.forPlayerWithInitialState(
+					player,
+					initialPlaybackState,
+					jest.fn(),
+					jest.fn(),
+					thresholdMilliseconds,
+				);
+
+				const localPositionAboveThreshold = initialPerformanceNow - thresholdMilliseconds;
+				playerCoordinator?.setPlaybackState(new PlayingPlaybackState(localPositionAboveThreshold));
+
+				expect(player.play).not.toHaveBeenCalled();
+				expect(player.pause).not.toHaveBeenCalled();
+				expect(player.currentTime).toBe(thresholdMilliseconds / 1000);
+			}, initialPerformanceNow);
+		});
+
+		it('does not skip an already playing player if the new position is below the threshold', async () => {
+			const initialPerformanceNow = 1000;
+
+			await TimeMock.run(async () => {
+				const player = mock<HTMLMediaElement>({
+					paused: false,
+					currentTime: 0,
+				});
+				const initialPlaybackState = new PlayingPlaybackState(initialPerformanceNow);
+				const thresholdMilliseconds = 1000;
+				const playerCoordinator = await PlayerCoordinator.forPlayerWithInitialState(
+					player,
+					initialPlaybackState,
+					jest.fn(),
+					jest.fn(),
+					thresholdMilliseconds,
+				);
+
+				const localPositionBelowThreshold = initialPerformanceNow - (thresholdMilliseconds - 1);
+				playerCoordinator?.setPlaybackState(new PlayingPlaybackState(localPositionBelowThreshold));
+
+				expect(player.play).not.toHaveBeenCalled();
+				expect(player.pause).not.toHaveBeenCalled();
+				expect(player.currentTime).toBe(0);
+			}, initialPerformanceNow);
+		});
+	});
+
+	// TODO: resetPlaybackState
+	// TODO: constant seeking doesn't spam skips (rate limiter)
+	// TODO: forwarding of playback changes caused by the user
+	// TODO: differentiates between skips caused by the user and caused by the playercoordinator itself (needs an integration test)
 });
 
 export {};


### PR DESCRIPTION
Fixes #188

This adds a threshold that needs to be exceeded before adjusting the position of the player while playing.

Note that this can only be implemented in the `PlayerCoordinator` because only that actually knows where the player is currently at.