### PR TITLE
Test the frontend build in our CI

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -23,6 +23,20 @@ jobs:
         run: npm install
       - name: ESLint & Prettier & Svelte check
         run: npm run lint
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install NodeJS
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: Install packages
+        run: npm install
+      - name: Build static files
+        run: npm run build
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/communityvi-frontend/package-lock.json
+++ b/communityvi-frontend/package-lock.json
@@ -1138,15 +1138,15 @@
 			"dev": true
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.0.0-next.177",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.177.tgz",
-			"integrity": "sha512-VPDeXAqAhBhpKaBpnaCYDQKrPg/B84LViA62GWGRnq0HUJ0sCex9fyWsdJCNHUes/pDEV9q8T6LgGU14XJ6qyQ==",
+			"version": "1.0.0-next.176",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.176.tgz",
+			"integrity": "sha512-aFwZ1PjOcxOSAX93Py3jfJBgZgWmANO5Vt2fb8abvNGLTA/d6VVArdPXSccaSxLYCGmgzvx+CAr8P+P8FcJ+Ng==",
 			"dev": true,
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.26",
+				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.24",
 				"cheap-watch": "^1.0.4",
 				"sade": "^1.7.4",
-				"vite": "^2.6.0"
+				"vite": "^2.5.7"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
@@ -1159,9 +1159,9 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.0-next.26",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.26.tgz",
-			"integrity": "sha512-+Rx3IBa4disskQmr+0/Rh+NYavkM6Vi8BnkTGjKnblawysw4INXkq2WEQBp8luGpUZEkjwczdL9Z9Q2hISvIeA==",
+			"version": "1.0.0-next.24",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.24.tgz",
+			"integrity": "sha512-b+n3jcLpk2j/25APQbk5ejCyd0faYTB2bOxR3gY0LX3MFGgdiL8zdf3/aawcPSxLdbL73YVlxNBIATGuvq03uQ==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^4.1.1",
@@ -1177,7 +1177,7 @@
 			"peerDependencies": {
 				"diff-match-patch": "^1.0.5",
 				"svelte": "^3.34.0",
-				"vite": "^2.6.0"
+				"vite": "^2.5.3"
 			},
 			"peerDependenciesMeta": {
 				"diff-match-patch": {
@@ -2795,240 +2795,14 @@
 			"dev": true
 		},
 		"node_modules/esbuild": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.3.tgz",
-			"integrity": "sha512-98xovMLKnyhv3gcReUuAEi5Ig1rK6SIgvsJuBIcfwzqGSEHsV8UJjMlmkhHoHMf9XZybMpE9Zax8AA8f7i2hlQ==",
+			"version": "0.12.29",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
+			"integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
-			},
-			"optionalDependencies": {
-				"esbuild-android-arm64": "0.13.3",
-				"esbuild-darwin-64": "0.13.3",
-				"esbuild-darwin-arm64": "0.13.3",
-				"esbuild-freebsd-64": "0.13.3",
-				"esbuild-freebsd-arm64": "0.13.3",
-				"esbuild-linux-32": "0.13.3",
-				"esbuild-linux-64": "0.13.3",
-				"esbuild-linux-arm": "0.13.3",
-				"esbuild-linux-arm64": "0.13.3",
-				"esbuild-linux-mips64le": "0.13.3",
-				"esbuild-linux-ppc64le": "0.13.3",
-				"esbuild-openbsd-64": "0.13.3",
-				"esbuild-sunos-64": "0.13.3",
-				"esbuild-windows-32": "0.13.3",
-				"esbuild-windows-64": "0.13.3",
-				"esbuild-windows-arm64": "0.13.3"
 			}
-		},
-		"node_modules/esbuild-android-arm64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.3.tgz",
-			"integrity": "sha512-jc9E8vGTHkzb0Vwl74H8liANV9BWsqtzLHaKvcsRgf1M+aVCBSF0gUheduAKfDsbDMT0judeMLhwBP34EUesTA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/esbuild-darwin-64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.3.tgz",
-			"integrity": "sha512-8bG3Zq+ZNuLlIJebOO2+weI7P2LVf33sOzaUfHj8MuJ+1Ixe4KtQxfYp7qhFnP6xP2ToJaYHxGUfLeiUCEz9hw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/esbuild-darwin-arm64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.3.tgz",
-			"integrity": "sha512-5E81eImYtTgh8pY7Gq4WQHhWkR/LvYadUXmuYeZBiP+3ADZJZcG60UFceZrjqNPaFOWKr/xmh4aNocwagEubcA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/esbuild-freebsd-64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.3.tgz",
-			"integrity": "sha512-ou+f91KkTGexi8HvF/BdtsITL6plbciQfZGys7QX6/QEwyE96PmL5KnU6ZQwoU7E99Ts6Sc9bUDq8HXJubKtBA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/esbuild-freebsd-arm64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.3.tgz",
-			"integrity": "sha512-F1zV7nySjHswJuvIgjkiG5liZ63MeazDGXGKViTCeegjZ71sAhOChcaGhKcu6vq9+vqZxlfEi1fmXlx6Pc3coQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/esbuild-linux-32": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.3.tgz",
-			"integrity": "sha512-mHHc2v6uLrHH4zaaq5RB/5IWzgimEJ1HGldzf1qtGI513KZWfH0HRRQ8p1di4notJgBn7tDzWQ1f34ZHy69viQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/esbuild-linux-64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.3.tgz",
-			"integrity": "sha512-FJ1De2O89mrOuqtaEXu41qIYJU6R41F+OA6vheNwcAQcX8fu0aiA13FJeLABq29BYJuTVgRj3cyC8q+tz19/dQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/esbuild-linux-arm": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.3.tgz",
-			"integrity": "sha512-9BJNRtLwBh3OP22cln9g3AJdbAQUcjRHqA4BScx9k4RZpGqPokFr548zpeplxWhcwrIjT8qPebwH9CrRVy8Bsw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/esbuild-linux-arm64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.3.tgz",
-			"integrity": "sha512-Cauhr45KSo+wRUojs+1qfycQqQCAXTOvsWvkZ6xmEMAXLAm+f8RQGDQeP8CAf8Yeelnegcn6UNdvzdzLHhWDFg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/esbuild-linux-mips64le": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.3.tgz",
-			"integrity": "sha512-YVzJUGCncuuLm2boYyVeuMFsak4ZAhdiBwi0xNDZCC8sy+tS6Boe2mzcrD2uubv5JKAUOrpN186S1DtU4WgBgw==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/esbuild-linux-ppc64le": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.3.tgz",
-			"integrity": "sha512-GU6CqqKtJEoyxC2QWHiJtmuOz9wc/jMv8ZloK2WwiGY5yMvAmM3PI103Dj7xcjebNTHBqITTUw/aigY1wx5A3w==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/esbuild-openbsd-64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.3.tgz",
-			"integrity": "sha512-HVpkgpn4BQt4BPDAjTOpeMub6mzNWw6Y3gaLQJrpbO24pws6ZwYkY24OI3/Uo3LDCbH6856MM81JxECt92OWjA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"openbsd"
-			]
-		},
-		"node_modules/esbuild-sunos-64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.3.tgz",
-			"integrity": "sha512-XncBVOtnEfUbPV4CaiFBxh38ychnBfwCxuTm9iAqcHzIwkmeNRN5qMzDyfE1jyfJje+Bbt6AvIfz6SdYt8/UEQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"sunos"
-			]
-		},
-		"node_modules/esbuild-windows-32": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.3.tgz",
-			"integrity": "sha512-ZlgDz7d1nk8wQACi+z8IDzNZVUlN9iprAme+1YSTsfFDlkyI8jeaGWPk9EQFNY7rJzsLVYm6eZ2mhPioc7uT5A==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/esbuild-windows-64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.3.tgz",
-			"integrity": "sha512-YX7KvRez3TR+GudlQm9tND/ssj2FsF9vb8ZWzAoZOLxpPzE3y+3SFJNrfDzzQKPzJ0Pnh9KBP4gsaMwJjKHDhw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/esbuild-windows-arm64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.3.tgz",
-			"integrity": "sha512-nP7H0Y2a6OJd3Qi1Q8sehhyP4x4JoXK4S5y6FzH2vgaJgiyEurzFxjUufGdMaw+RxtxiwD/uRndUgwaZ2JD8lg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			]
 		},
 		"node_modules/escalade": {
 			"version": "3.1.1",
@@ -6322,12 +6096,12 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.3.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.8.tgz",
-			"integrity": "sha512-GT5bTjjZnwDifajzczOC+r3FI3Cu+PgPvrsjhQdRqa2kTJ4968/X9CUce9xttIB0xOs5c6xf0TCWZo/y9lF6bA==",
+			"version": "8.3.7",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.7.tgz",
+			"integrity": "sha512-9SaY7nnyQ63/WittqZYAvkkYPyKxchMKH71UDzeTmWuLSvxTRpeEeABZAzlCi55cuGcoFyoV/amX2BdsafQidQ==",
 			"dev": true,
 			"dependencies": {
-				"nanocolors": "^0.2.2",
+				"nanocolors": "^0.1.5",
 				"nanoid": "^3.1.25",
 				"source-map-js": "^0.6.2"
 			},
@@ -6338,12 +6112,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/postcss/"
 			}
-		},
-		"node_modules/postcss/node_modules/nanocolors": {
-			"version": "0.2.12",
-			"resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.12.tgz",
-			"integrity": "sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug==",
-			"dev": true
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -8433,15 +8201,15 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.6.1.tgz",
-			"integrity": "sha512-rYd+iGMQ+AytWfYBDhIz2upeiseuqrAMwmApJDR40wu12C9MqzemX449nM3FN1Z/FFSV+fMTFz7eMenngVSogA==",
+			"version": "2.5.10",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.5.10.tgz",
+			"integrity": "sha512-0ObiHTi5AHyXdJcvZ67HMsDgVpjT5RehvVKv6+Q0jFZ7zDI28PF5zK9mYz2avxdA+4iJMdwCz6wnGNnn4WX5Gg==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.13.2",
-				"postcss": "^8.3.8",
+				"esbuild": "^0.12.17",
+				"postcss": "^8.3.6",
 				"resolve": "^1.20.0",
-				"rollup": "^2.57.0"
+				"rollup": "^2.38.5"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -8451,22 +8219,6 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
-			},
-			"peerDependencies": {
-				"less": "*",
-				"sass": "*",
-				"stylus": "*"
-			},
-			"peerDependenciesMeta": {
-				"less": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"stylus": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/w3c-hr-time": {
@@ -9556,21 +9308,21 @@
 			"dev": true
 		},
 		"@sveltejs/kit": {
-			"version": "1.0.0-next.177",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.177.tgz",
-			"integrity": "sha512-VPDeXAqAhBhpKaBpnaCYDQKrPg/B84LViA62GWGRnq0HUJ0sCex9fyWsdJCNHUes/pDEV9q8T6LgGU14XJ6qyQ==",
+			"version": "1.0.0-next.176",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.176.tgz",
+			"integrity": "sha512-aFwZ1PjOcxOSAX93Py3jfJBgZgWmANO5Vt2fb8abvNGLTA/d6VVArdPXSccaSxLYCGmgzvx+CAr8P+P8FcJ+Ng==",
 			"dev": true,
 			"requires": {
-				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.26",
+				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.24",
 				"cheap-watch": "^1.0.4",
 				"sade": "^1.7.4",
-				"vite": "^2.6.0"
+				"vite": "^2.5.7"
 			}
 		},
 		"@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.0-next.26",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.26.tgz",
-			"integrity": "sha512-+Rx3IBa4disskQmr+0/Rh+NYavkM6Vi8BnkTGjKnblawysw4INXkq2WEQBp8luGpUZEkjwczdL9Z9Q2hISvIeA==",
+			"version": "1.0.0-next.24",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.24.tgz",
+			"integrity": "sha512-b+n3jcLpk2j/25APQbk5ejCyd0faYTB2bOxR3gY0LX3MFGgdiL8zdf3/aawcPSxLdbL73YVlxNBIATGuvq03uQ==",
 			"dev": true,
 			"requires": {
 				"@rollup/pluginutils": "^4.1.1",
@@ -10824,140 +10576,10 @@
 			"dev": true
 		},
 		"esbuild": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.3.tgz",
-			"integrity": "sha512-98xovMLKnyhv3gcReUuAEi5Ig1rK6SIgvsJuBIcfwzqGSEHsV8UJjMlmkhHoHMf9XZybMpE9Zax8AA8f7i2hlQ==",
-			"dev": true,
-			"requires": {
-				"esbuild-android-arm64": "0.13.3",
-				"esbuild-darwin-64": "0.13.3",
-				"esbuild-darwin-arm64": "0.13.3",
-				"esbuild-freebsd-64": "0.13.3",
-				"esbuild-freebsd-arm64": "0.13.3",
-				"esbuild-linux-32": "0.13.3",
-				"esbuild-linux-64": "0.13.3",
-				"esbuild-linux-arm": "0.13.3",
-				"esbuild-linux-arm64": "0.13.3",
-				"esbuild-linux-mips64le": "0.13.3",
-				"esbuild-linux-ppc64le": "0.13.3",
-				"esbuild-openbsd-64": "0.13.3",
-				"esbuild-sunos-64": "0.13.3",
-				"esbuild-windows-32": "0.13.3",
-				"esbuild-windows-64": "0.13.3",
-				"esbuild-windows-arm64": "0.13.3"
-			}
-		},
-		"esbuild-android-arm64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.3.tgz",
-			"integrity": "sha512-jc9E8vGTHkzb0Vwl74H8liANV9BWsqtzLHaKvcsRgf1M+aVCBSF0gUheduAKfDsbDMT0judeMLhwBP34EUesTA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-darwin-64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.3.tgz",
-			"integrity": "sha512-8bG3Zq+ZNuLlIJebOO2+weI7P2LVf33sOzaUfHj8MuJ+1Ixe4KtQxfYp7qhFnP6xP2ToJaYHxGUfLeiUCEz9hw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-darwin-arm64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.3.tgz",
-			"integrity": "sha512-5E81eImYtTgh8pY7Gq4WQHhWkR/LvYadUXmuYeZBiP+3ADZJZcG60UFceZrjqNPaFOWKr/xmh4aNocwagEubcA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-freebsd-64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.3.tgz",
-			"integrity": "sha512-ou+f91KkTGexi8HvF/BdtsITL6plbciQfZGys7QX6/QEwyE96PmL5KnU6ZQwoU7E99Ts6Sc9bUDq8HXJubKtBA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-freebsd-arm64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.3.tgz",
-			"integrity": "sha512-F1zV7nySjHswJuvIgjkiG5liZ63MeazDGXGKViTCeegjZ71sAhOChcaGhKcu6vq9+vqZxlfEi1fmXlx6Pc3coQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-32": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.3.tgz",
-			"integrity": "sha512-mHHc2v6uLrHH4zaaq5RB/5IWzgimEJ1HGldzf1qtGI513KZWfH0HRRQ8p1di4notJgBn7tDzWQ1f34ZHy69viQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.3.tgz",
-			"integrity": "sha512-FJ1De2O89mrOuqtaEXu41qIYJU6R41F+OA6vheNwcAQcX8fu0aiA13FJeLABq29BYJuTVgRj3cyC8q+tz19/dQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-arm": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.3.tgz",
-			"integrity": "sha512-9BJNRtLwBh3OP22cln9g3AJdbAQUcjRHqA4BScx9k4RZpGqPokFr548zpeplxWhcwrIjT8qPebwH9CrRVy8Bsw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-arm64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.3.tgz",
-			"integrity": "sha512-Cauhr45KSo+wRUojs+1qfycQqQCAXTOvsWvkZ6xmEMAXLAm+f8RQGDQeP8CAf8Yeelnegcn6UNdvzdzLHhWDFg==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-mips64le": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.3.tgz",
-			"integrity": "sha512-YVzJUGCncuuLm2boYyVeuMFsak4ZAhdiBwi0xNDZCC8sy+tS6Boe2mzcrD2uubv5JKAUOrpN186S1DtU4WgBgw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-ppc64le": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.3.tgz",
-			"integrity": "sha512-GU6CqqKtJEoyxC2QWHiJtmuOz9wc/jMv8ZloK2WwiGY5yMvAmM3PI103Dj7xcjebNTHBqITTUw/aigY1wx5A3w==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-openbsd-64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.3.tgz",
-			"integrity": "sha512-HVpkgpn4BQt4BPDAjTOpeMub6mzNWw6Y3gaLQJrpbO24pws6ZwYkY24OI3/Uo3LDCbH6856MM81JxECt92OWjA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-sunos-64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.3.tgz",
-			"integrity": "sha512-XncBVOtnEfUbPV4CaiFBxh38ychnBfwCxuTm9iAqcHzIwkmeNRN5qMzDyfE1jyfJje+Bbt6AvIfz6SdYt8/UEQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-windows-32": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.3.tgz",
-			"integrity": "sha512-ZlgDz7d1nk8wQACi+z8IDzNZVUlN9iprAme+1YSTsfFDlkyI8jeaGWPk9EQFNY7rJzsLVYm6eZ2mhPioc7uT5A==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-windows-64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.3.tgz",
-			"integrity": "sha512-YX7KvRez3TR+GudlQm9tND/ssj2FsF9vb8ZWzAoZOLxpPzE3y+3SFJNrfDzzQKPzJ0Pnh9KBP4gsaMwJjKHDhw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-windows-arm64": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.3.tgz",
-			"integrity": "sha512-nP7H0Y2a6OJd3Qi1Q8sehhyP4x4JoXK4S5y6FzH2vgaJgiyEurzFxjUufGdMaw+RxtxiwD/uRndUgwaZ2JD8lg==",
-			"dev": true,
-			"optional": true
+			"version": "0.12.29",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
+			"integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==",
+			"dev": true
 		},
 		"escalade": {
 			"version": "3.1.1",
@@ -13488,22 +13110,14 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.3.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.8.tgz",
-			"integrity": "sha512-GT5bTjjZnwDifajzczOC+r3FI3Cu+PgPvrsjhQdRqa2kTJ4968/X9CUce9xttIB0xOs5c6xf0TCWZo/y9lF6bA==",
+			"version": "8.3.7",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.7.tgz",
+			"integrity": "sha512-9SaY7nnyQ63/WittqZYAvkkYPyKxchMKH71UDzeTmWuLSvxTRpeEeABZAzlCi55cuGcoFyoV/amX2BdsafQidQ==",
 			"dev": true,
 			"requires": {
-				"nanocolors": "^0.2.2",
+				"nanocolors": "^0.1.5",
 				"nanoid": "^3.1.25",
 				"source-map-js": "^0.6.2"
-			},
-			"dependencies": {
-				"nanocolors": {
-					"version": "0.2.12",
-					"resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.12.tgz",
-					"integrity": "sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug==",
-					"dev": true
-				}
 			}
 		},
 		"prelude-ls": {
@@ -15094,16 +14708,16 @@
 			}
 		},
 		"vite": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.6.1.tgz",
-			"integrity": "sha512-rYd+iGMQ+AytWfYBDhIz2upeiseuqrAMwmApJDR40wu12C9MqzemX449nM3FN1Z/FFSV+fMTFz7eMenngVSogA==",
+			"version": "2.5.10",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.5.10.tgz",
+			"integrity": "sha512-0ObiHTi5AHyXdJcvZ67HMsDgVpjT5RehvVKv6+Q0jFZ7zDI28PF5zK9mYz2avxdA+4iJMdwCz6wnGNnn4WX5Gg==",
 			"dev": true,
 			"requires": {
-				"esbuild": "^0.13.2",
+				"esbuild": "^0.12.17",
 				"fsevents": "~2.3.2",
-				"postcss": "^8.3.8",
+				"postcss": "^8.3.6",
 				"resolve": "^1.20.0",
-				"rollup": "^2.57.0"
+				"rollup": "^2.38.5"
 			}
 		},
 		"w3c-hr-time": {


### PR DESCRIPTION
An update to sveltekit broke our build of static files. This wasn't caught by the CI for frontend changes, only by the backend CI that tries to bundle the frontend.

This fixes the CI to fail faster in that case and reverts the offending commit.