### PR TITLE
Initial REST API endpoint

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -11,6 +11,31 @@ defaults:
 env:
   CARGO_TERM_COLOR: always
 jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install NodeJS
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+      - name: Check
+        run: cargo check
+      - name: Check without defaults
+        run: cargo check --no-default-features
+      - name: Check api-docs
+        run: cargo check --features api-docs
+      - name: Check bundle-frontend
+        run: cargo check --features bundle-frontend
+      - name: Check all features
+        run: cargo check --all-features
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/communityvi-frontend/src/lib/client/RESTClient.ts
+++ b/communityvi-frontend/src/lib/client/RESTClient.ts
@@ -5,15 +5,86 @@ export class RESTClient {
 		this.apiBaseURL = apiBaseURL;
 	}
 
-	async getReferenceTimeMilliseconds(): Promise<number> {
-		const response = await window.fetch(`${this.apiBaseURL}/reference_time_milliseconds`);
+	async getReferenceTimeMilliseconds(): Promise<ReferenceTimeResponse> {
+		const request = new XMLHttpRequest();
+		request.open('GET', `${this.apiBaseURL}/reference_time_milliseconds`, true);
 
-		const milliseconds = await response.json();
+		const response = await RESTClient.getWithTimings(`${this.apiBaseURL}/reference_time_milliseconds`);
+
+		const milliseconds = JSON.parse(response.text);
 		if (typeof milliseconds !== 'number') {
 			throw new RESTError(`Invalid reference time response: '${milliseconds}'`);
 		}
 
-		return milliseconds;
+		return new ReferenceTimeResponse(milliseconds, response.sentAtMilliseconds, response.receivedAtMilliseconds);
+	}
+
+	private static async getWithTimings(url: string): Promise<ResponseWithTimings> {
+		// Uses `XMLHttpRequest` to get more accurate timings of how long a request takes.
+		// The alternative, running performance.now() before and after `await window.fetch(...)`
+		// has problems with timings being off by more than 100ms sometimes.
+		// This most likely comes down to promises running in the time between when the response
+		// was received and the continuation after the await is run.
+		// `XMLHttpRequest` has the `loadstart` event that already contains a timestamp of when
+		// the event was created, so it is much more accurate although the timings can still vary
+		// an order of magnitude more than with a websocket based request/response pattern.
+
+		const request = new XMLHttpRequest();
+		request.open('GET', url, true);
+
+		let sentAtMilliseconds: number | undefined;
+		let receivedAtMilliseconds: number | undefined;
+
+		const requestPromise: Promise<string> = new Promise((resolve, reject) => {
+			// This is the first event we receive that a response has arrived
+			request.onloadstart = event => {
+				receivedAtMilliseconds = event.timeStamp;
+			};
+
+			request.onerror = event => {
+				reject(new RESTError(`Error performing get request to '${url}': '${event}'`));
+			};
+
+			request.onload = () => {
+				resolve(request.responseText);
+			};
+
+			sentAtMilliseconds = performance.now();
+			request.send();
+		});
+
+		const text = await requestPromise;
+		if (sentAtMilliseconds === undefined || receivedAtMilliseconds === undefined) {
+			throw new RESTError(`Failed to time request to '${url}'`);
+		}
+
+		return {
+			text,
+			sentAtMilliseconds,
+			receivedAtMilliseconds,
+		};
+	}
+}
+
+interface ResponseWithTimings {
+	text: string;
+	sentAtMilliseconds: number;
+	receivedAtMilliseconds: number;
+}
+
+export class ReferenceTimeResponse {
+	readonly referenceTimeInMilliseconds: number;
+	readonly sentAtMilliseconds: number;
+	readonly receivedAtMilliseconds: number;
+
+	constructor(referenceTimeInMilliseconds: number, sentAtMilliseconds: number, receivedAtMilliseconds: number) {
+		this.referenceTimeInMilliseconds = referenceTimeInMilliseconds;
+		this.sentAtMilliseconds = sentAtMilliseconds;
+		this.receivedAtMilliseconds = receivedAtMilliseconds;
+	}
+
+	get roundtripTimeInMilliseconds(): number {
+		return this.receivedAtMilliseconds - this.sentAtMilliseconds;
 	}
 }
 

--- a/communityvi-frontend/src/lib/client/RESTClient.ts
+++ b/communityvi-frontend/src/lib/client/RESTClient.ts
@@ -1,0 +1,24 @@
+export class RESTClient {
+	private readonly apiBaseURL: URL;
+
+	constructor(apiBaseURL: URL) {
+		this.apiBaseURL = apiBaseURL;
+	}
+
+	async getReferenceTimeMilliseconds(): Promise<number> {
+		const response = await window.fetch(`${this.apiBaseURL}/reference_time_milliseconds`);
+
+		const milliseconds = await response.json();
+		if (typeof milliseconds !== 'number') {
+			throw new RESTError(`Invalid reference time response: '${milliseconds}'`);
+		}
+
+		return milliseconds;
+	}
+}
+
+class RESTError extends Error {
+	constructor(message: string) {
+		super(`RESTError: ${message}`);
+	}
+}

--- a/communityvi-frontend/src/lib/client/RESTClient.ts
+++ b/communityvi-frontend/src/lib/client/RESTClient.ts
@@ -6,10 +6,7 @@ export class RESTClient {
 	}
 
 	async getReferenceTimeMilliseconds(): Promise<ReferenceTimeResponse> {
-		const request = new XMLHttpRequest();
-		request.open('GET', `${this.apiBaseURL}/reference_time_milliseconds`, true);
-
-		const response = await RESTClient.getWithTimings(`${this.apiBaseURL}/reference_time_milliseconds`);
+		const response = await RESTClient.getWithTimings(`${this.apiBaseURL}/reference-time-milliseconds`);
 
 		const milliseconds = JSON.parse(response.text);
 		if (typeof milliseconds !== 'number') {

--- a/communityvi-frontend/src/lib/client/client.ts
+++ b/communityvi-frontend/src/lib/client/client.ts
@@ -21,7 +21,9 @@ export default class Client {
 		const response = (await connection.performRequest(new RegisterRequest(name))).response as HelloMessage;
 		const peers = response.clients.map(Peer.fromClientResponse);
 
-		const referenceTimeSynchronizer = await ReferenceTimeSynchronizer.createInitializedWithConnection(connection);
+		const referenceTimeSynchronizer = await ReferenceTimeSynchronizer.createInitializedWithRESTClient(
+			this.restClient,
+		);
 		const versionedMedium = VersionedMedium.fromVersionedMediumResponseAndReferenceTimeOffset(
 			response.current_medium,
 			referenceTimeSynchronizer.offset,

--- a/communityvi-frontend/src/lib/client/client.ts
+++ b/communityvi-frontend/src/lib/client/client.ts
@@ -4,12 +4,15 @@ import type {Transport} from '$lib/client/transport';
 import {Peer, VersionedMedium} from '$lib/client/model';
 import ReferenceTimeSynchronizer from '$lib/client/reference_time_synchronizer';
 import RegisteredClient, {DisconnectCallback} from '$lib/client/registered_client';
+import {RESTClient} from '$lib/client/RESTClient';
 
 export default class Client {
 	readonly transport: Transport;
+	readonly restClient: RESTClient;
 
-	constructor(transport: Transport) {
+	constructor(transport: Transport, restClient: RESTClient) {
 		this.transport = transport;
+		this.restClient = restClient;
 	}
 
 	async register(name: string, disconnectCallback: DisconnectCallback): Promise<RegisteredClient> {
@@ -30,6 +33,7 @@ export default class Client {
 			referenceTimeSynchronizer,
 			versionedMedium,
 			peers,
+			this.restClient,
 			connection,
 			disconnectCallback,
 		);

--- a/communityvi-frontend/src/lib/client/reference_time_synchronizer.ts
+++ b/communityvi-frontend/src/lib/client/reference_time_synchronizer.ts
@@ -53,17 +53,13 @@ export default class ReferenceTimeSynchronizer {
 	}
 
 	private static async fetchReferenceTimeAndCalculateOffset(restClient: RESTClient): Promise<number> {
-		// NOTE: If this isn't accurate enough, it might be worth investigating the use of XMLHttpRequest and the
-		// 'onloadstart' events timeStamp property.
-		const sentAt = performance.now();
-		const referenceTime = await restClient.getReferenceTimeMilliseconds();
-		const receivedAt = performance.now();
+		const response = await restClient.getReferenceTimeMilliseconds();
 
 		// We assume that the request takes the same time to the server as the response takes back to us.
 		// Therefore, the server's reference time represents our time half way the message exchange.
-		const ourTime = sentAt + (receivedAt - sentAt) / 2;
+		const ourTime = response.sentAtMilliseconds + response.roundtripTimeInMilliseconds / 2;
 
-		return referenceTime - ourTime;
+		return response.referenceTimeInMilliseconds - ourTime;
 	}
 
 	calculateServerTimeFromLocalTime(localTimeInMilliseconds: number): number {

--- a/communityvi-frontend/src/lib/client/reference_time_synchronizer.ts
+++ b/communityvi-frontend/src/lib/client/reference_time_synchronizer.ts
@@ -1,26 +1,26 @@
-import type {Connection} from '$lib/client/connection';
-import {GetReferenceTimeRequest} from '$lib/client/request';
-import type {ReferenceTimeMessage} from '$lib/client/response';
+import {RESTClient} from '$lib/client/RESTClient';
 
 export default class ReferenceTimeSynchronizer {
-	private readonly connection: Connection;
+	private readonly restClient: RESTClient;
 	private callback?: TimeUpdatedCallback;
 	private intervalId?: NodeJS.Timeout;
 
 	private storedOffset: number;
 
+	static UPDATE_INTERVAL_MILLISECONDS = 15_000;
+
 	get offset(): number {
 		return this.storedOffset;
 	}
 
-	static async createInitializedWithConnection(connection: Connection): Promise<ReferenceTimeSynchronizer> {
-		const initialOffset = await ReferenceTimeSynchronizer.fetchReferenceTimeAndCalculateOffset(connection);
-		return new ReferenceTimeSynchronizer(initialOffset, connection);
+	static async createInitializedWithRESTClient(restClient: RESTClient): Promise<ReferenceTimeSynchronizer> {
+		const initialOffset = await ReferenceTimeSynchronizer.fetchReferenceTimeAndCalculateOffset(restClient);
+		return new ReferenceTimeSynchronizer(initialOffset, restClient);
 	}
 
-	private constructor(initialOffset: number, connection: Connection) {
+	private constructor(initialOffset: number, restClient: RESTClient) {
+		this.restClient = restClient;
 		this.storedOffset = initialOffset;
-		this.connection = connection;
 	}
 
 	start(callback: TimeUpdatedCallback): void {
@@ -30,12 +30,14 @@ export default class ReferenceTimeSynchronizer {
 
 		this.callback = callback;
 
-		// Schedule reference time updates every 15s
-		this.intervalId = setInterval(() => this.synchronizeReferenceTime(), 15_000);
+		this.intervalId = setInterval(
+			() => this.synchronizeReferenceTime(),
+			ReferenceTimeSynchronizer.UPDATE_INTERVAL_MILLISECONDS,
+		);
 	}
 
 	private async synchronizeReferenceTime(): Promise<void> {
-		const newOffset = await ReferenceTimeSynchronizer.fetchReferenceTimeAndCalculateOffset(this.connection);
+		const newOffset = await ReferenceTimeSynchronizer.fetchReferenceTimeAndCalculateOffset(this.restClient);
 		if (this.storedOffset === newOffset) {
 			console.debug('Reference time did not need updating.');
 			return;
@@ -50,13 +52,16 @@ export default class ReferenceTimeSynchronizer {
 		}
 	}
 
-	private static async fetchReferenceTimeAndCalculateOffset(connection: Connection): Promise<number> {
-		const response = await connection.performRequest(new GetReferenceTimeRequest());
+	private static async fetchReferenceTimeAndCalculateOffset(restClient: RESTClient): Promise<number> {
+		// NOTE: If this isn't accurate enough, it might be worth investigating the use of XMLHttpRequest and the
+		// 'onloadstart' events timeStamp property.
+		const sentAt = performance.now();
+		const referenceTime = await restClient.getReferenceTimeMilliseconds();
+		const receivedAt = performance.now();
 
 		// We assume that the request takes the same time to the server as the response takes back to us.
 		// Therefore, the server's reference time represents our time half way the message exchange.
-		const ourTime = response.metadata.sentAt + response.metadata.roundTripTimeInMilliseconds / 2;
-		const referenceTime = (response.response as ReferenceTimeMessage).milliseconds;
+		const ourTime = sentAt + (receivedAt - sentAt) / 2;
 
 		return referenceTime - ourTime;
 	}

--- a/communityvi-frontend/src/lib/client/registered_client.ts
+++ b/communityvi-frontend/src/lib/client/registered_client.ts
@@ -32,6 +32,7 @@ import {
 } from '$lib/client/model';
 import MessageBroker, {Subscriber, Unsubscriber} from '$lib/client/message_broker';
 import type ReferenceTimeSynchronizer from '$lib/client/reference_time_synchronizer';
+import {RESTClient} from '$lib/client/RESTClient';
 
 export default class RegisteredClient {
 	readonly id: number;
@@ -39,6 +40,8 @@ export default class RegisteredClient {
 	private referenceTimeSynchronizer: ReferenceTimeSynchronizer;
 	private versionedMedium: VersionedMedium;
 	readonly peers: Array<Peer>;
+
+	private readonly restClient: RESTClient;
 
 	private readonly connection: Connection;
 	private readonly disconnectCallback: DisconnectCallback;
@@ -57,6 +60,7 @@ export default class RegisteredClient {
 		referenceTimeSynchronizer: ReferenceTimeSynchronizer,
 		versionedMedium: VersionedMedium,
 		peers: Array<Peer>,
+		restClient: RESTClient,
 		connection: Connection,
 		disconnectCallback: DisconnectCallback,
 	) {
@@ -65,6 +69,8 @@ export default class RegisteredClient {
 		this.referenceTimeSynchronizer = referenceTimeSynchronizer;
 		this.versionedMedium = versionedMedium;
 		this.peers = peers;
+
+		this.restClient = restClient;
 
 		this.connection = connection;
 		this.disconnectCallback = disconnectCallback;

--- a/communityvi-frontend/src/lib/client/request.ts
+++ b/communityvi-frontend/src/lib/client/request.ts
@@ -24,10 +24,6 @@ export class PlayRequest implements ClientRequest {
 	}
 }
 
-export class GetReferenceTimeRequest implements ClientRequest {
-	type = RequestType.GetReferenceTime;
-}
-
 export class InsertMediumRequest implements ClientRequest {
 	type = RequestType.InsertMedium;
 	readonly previous_version: number;
@@ -93,7 +89,6 @@ enum RequestType {
 	Register = 'register',
 	Chat = 'chat',
 	InsertMedium = 'insert_medium',
-	GetReferenceTime = 'get_reference_time',
 	Play = 'play',
 	Pause = 'pause',
 }

--- a/communityvi-frontend/src/lib/client/response.ts
+++ b/communityvi-frontend/src/lib/client/response.ts
@@ -1,9 +1,5 @@
 import type {MediumType} from '$lib/client/request';
 
-export interface ReferenceTimeMessage extends SuccessMessage {
-	readonly milliseconds: number;
-}
-
 export interface HelloMessage extends SuccessMessage {
 	readonly id: number;
 	readonly clients: Array<ClientResponse>;
@@ -49,7 +45,6 @@ export interface SuccessMessage {
 
 export enum SuccessMessageType {
 	Hello = 'hello',
-	ReferenceTime = 'reference_time',
 	Success = 'success',
 }
 

--- a/communityvi-frontend/src/routes/index.svelte
+++ b/communityvi-frontend/src/routes/index.svelte
@@ -12,16 +12,29 @@
 	import Player from '$lib/components/player/Player.svelte';
 	import {page} from '$app/stores';
 	import {browser} from '$app/env';
+	import {RESTClient} from '$lib/client/RESTClient';
 
-	const transport = new WebSocketTransport(determineBackendURL());
-	const client = new Client(transport);
+	const transport = new WebSocketTransport(determineWebSocketURL());
+	const restClient = new RESTClient(determineAPIUrl());
+	const client = new Client(transport, restClient);
 
-	function determineBackendURL(): URL {
+	function determineWebSocketURL(): URL {
 		// Just a stopgap measure for now. The (generally wrong) assumption is that
 		// the backend listens on port 8000. But this is good enough for now because it
 		// works both with `npm run watch` and the default backend settings as well
 		// as when the frontend is bundled with the backend.
 		const url = new URL(`ws://${pageHost()}/ws`);
+		url.port = '8000';
+
+		return url;
+	}
+
+	function determineAPIUrl(): URL {
+		// Just a stopgap measure for now. The (generally wrong) assumption is that
+		// the backend listens on port 8000. But this is good enough for now because it
+		// works both with `npm run watch` and the default backend settings as well
+		// as when the frontend is bundled with the backend.
+		const url = new URL(`http://${pageHost()}/api`);
 		url.port = '8000';
 
 		return url;

--- a/communityvi-frontend/tests/client/helper/registered_client_builder.ts
+++ b/communityvi-frontend/tests/client/helper/registered_client_builder.ts
@@ -4,6 +4,7 @@ import {mock} from 'jest-mock-extended';
 import type ReferenceTimeSynchronizer from '$lib/client/reference_time_synchronizer';
 import type {Connection} from '$lib/client/connection';
 import Faker from 'faker';
+import {RESTClient} from '$lib/client/RESTClient';
 
 export class RegisteredClientBuilder {
 	private storedID = Faker.datatype.number({min: 0});
@@ -12,6 +13,7 @@ export class RegisteredClientBuilder {
 	private storedReferenceTimeSynchronizer: ReferenceTimeSynchronizer;
 	private storedVersionedMedium = new VersionedMedium(Faker.datatype.number({min: 0}));
 	private storedPeers = new Array<Peer>();
+	private storedRestClient: RESTClient = mock<RESTClient>();
 	private storedConnection: Connection = mock<Connection>();
 	private storedDisconnectCallback: DisconnectCallback = jest.fn();
 
@@ -71,6 +73,12 @@ export class RegisteredClientBuilder {
 		return this;
 	}
 
+	restClient(restClient: RESTClient): RegisteredClientBuilder {
+		this.storedRestClient = restClient;
+
+		return this;
+	}
+
 	connection(connection: Connection): RegisteredClientBuilder {
 		this.storedConnection = connection;
 
@@ -90,6 +98,7 @@ export class RegisteredClientBuilder {
 			this.storedReferenceTimeSynchronizer,
 			this.storedVersionedMedium,
 			this.storedPeers,
+			this.storedRestClient,
 			this.storedConnection,
 			this.storedDisconnectCallback,
 		);

--- a/communityvi-frontend/tests/client/helper/test_transport.ts
+++ b/communityvi-frontend/tests/client/helper/test_transport.ts
@@ -2,14 +2,8 @@ import type {Transport} from '$lib/client/transport';
 import {WebSocketTransport} from '$lib/client/transport';
 import type {Connection} from '$lib/client/connection';
 import {mock} from 'jest-mock-extended';
-import {
-	ClientResponse,
-	HelloMessage,
-	ReferenceTimeMessage,
-	SuccessMessageType,
-	VersionedMediumResponse,
-} from '$lib/client/response';
-import {GetReferenceTimeRequest, MediumType, RegisterRequest} from '$lib/client/request';
+import {ClientResponse, HelloMessage, SuccessMessageType, VersionedMediumResponse} from '$lib/client/response';
+import {MediumType, RegisterRequest} from '$lib/client/request';
 import {Peer} from '$lib/client/model';
 import {EnrichedResponse, ResponseMetadata} from '$lib/client/connection';
 
@@ -55,20 +49,9 @@ export default class TestTransport implements Transport {
 		const helloMessageMetadata = new ResponseMetadata(performance.now(), performance.now() + 1);
 		const helloResponse = new EnrichedResponse(helloMessage, helloMessageMetadata);
 
-		const referenceTimeMessage = <ReferenceTimeMessage>{
-			type: SuccessMessageType.ReferenceTime,
-			milliseconds: performance.now() - 1,
-		};
-		const referenceTimeMessageMetadata = new ResponseMetadata(performance.now(), performance.now() + 1);
-		const referenceTimeResponse = new EnrichedResponse(referenceTimeMessage, referenceTimeMessageMetadata);
-
 		mockedConnection.performRequest.mockImplementation(request => {
 			if (request instanceof RegisterRequest) {
 				return Promise.resolve(helloResponse);
-			}
-
-			if (request instanceof GetReferenceTimeRequest) {
-				return Promise.resolve(referenceTimeResponse);
 			}
 
 			return Promise.reject(`Don't know how to mock request: '${request.type}'`);

--- a/communityvi-frontend/tests/client/reference_time_synchronizer.spec.ts
+++ b/communityvi-frontend/tests/client/reference_time_synchronizer.spec.ts
@@ -1,7 +1,7 @@
 import ReferenceTimeSynchronizer, {AlreadyRunningError} from '$lib/client/reference_time_synchronizer';
 import {CalledWithMock, mock, mockReset} from 'jest-mock-extended';
 import TimeMock from './helper/time_mock';
-import {RESTClient} from '$lib/client/RESTClient';
+import {ReferenceTimeResponse, RESTClient} from '$lib/client/RESTClient';
 
 describe('The reference time synchronizer', () => {
 	it('should not allow starting synchronization twice', async () => {
@@ -85,12 +85,13 @@ function scheduleReferenceTimeResponse(
 ) {
 	mockReset(restClient);
 	restClient.getReferenceTimeMilliseconds.mockImplementationOnce(async () => {
+		const sentAt = performance.now();
 		if (timeMock !== undefined) {
 			await timeMock?.advanceTimeByMilliseconds(pingMilliseconds);
 		}
 
-		return referenceTime + pingMilliseconds / 2;
+		return new ReferenceTimeResponse(referenceTime + pingMilliseconds / 2, sentAt, sentAt + pingMilliseconds);
 	});
 }
 
-type RESTClientMock = {getReferenceTimeMilliseconds: CalledWithMock<Promise<number>, []>} & RESTClient;
+type RESTClientMock = {getReferenceTimeMilliseconds: CalledWithMock<Promise<ReferenceTimeResponse>, []>} & RESTClient;

--- a/communityvi-frontend/tests/client/reference_time_synchronizer.spec.ts
+++ b/communityvi-frontend/tests/client/reference_time_synchronizer.spec.ts
@@ -1,19 +1,15 @@
 import ReferenceTimeSynchronizer, {AlreadyRunningError} from '$lib/client/reference_time_synchronizer';
-import type {Connection} from '$lib/client/connection';
-import {EnrichedResponse, ResponseMetadata} from '$lib/client/connection';
-import {CalledWithMock, isA, mock, mockReset} from 'jest-mock-extended';
-import {ClientRequest, GetReferenceTimeRequest} from '$lib/client/request';
-import type {ReferenceTimeMessage} from '$lib/client/response';
-import {SuccessMessageType} from '$lib/client/response';
+import {CalledWithMock, mock, mockReset} from 'jest-mock-extended';
 import TimeMock from './helper/time_mock';
+import {RESTClient} from '$lib/client/RESTClient';
 
 describe('The reference time synchronizer', () => {
 	it('should not allow starting synchronization twice', async () => {
-		const connectionMock = mock<Connection>();
-		scheduleReferenceTimeResponse(connectionMock, 1337, 0, 0);
+		const restClientMock = mock<RESTClient>();
+		scheduleReferenceTimeResponse(restClientMock, 1337);
 
-		const referenceTimeSynchronizer = await ReferenceTimeSynchronizer.createInitializedWithConnection(
-			connectionMock,
+		const referenceTimeSynchronizer = await ReferenceTimeSynchronizer.createInitializedWithRESTClient(
+			restClientMock,
 		);
 
 		referenceTimeSynchronizer.start(jest.fn());
@@ -22,22 +18,25 @@ describe('The reference time synchronizer', () => {
 	});
 
 	it('should have the correct initial offset after construction', async () => {
-		const connectionMock = mock<Connection>();
-		scheduleReferenceTimeResponse(connectionMock, 1337, 0, 1000);
+		await TimeMock.run(async (timeMock: TimeMock) => {
+			const restClientMock = mock<RESTClient>();
+			scheduleReferenceTimeResponse(restClientMock, 1337, timeMock, 1_000);
 
-		const referenceTimeSynchronizer = await ReferenceTimeSynchronizer.createInitializedWithConnection(
-			connectionMock,
-		);
+			const referenceTimeSynchronizer = await ReferenceTimeSynchronizer.createInitializedWithRESTClient(
+				restClientMock,
+			);
 
-		expect(referenceTimeSynchronizer.offset).toBe(1337);
+			expect(referenceTimeSynchronizer.offset).toBe(1337);
+		});
 	});
 
 	it('should inform its subscriber about offset updates', async () => {
 		await TimeMock.run(async (timeMock: TimeMock) => {
-			const connectionMock = mock<Connection>();
-			scheduleReferenceTimeResponse(connectionMock, 1337, 0, 1000);
-			const referenceTimeSynchronizer = await ReferenceTimeSynchronizer.createInitializedWithConnection(
-				connectionMock,
+			const initialReferenceTime = 1337;
+			const restClientMock = mock<RESTClient>();
+			scheduleReferenceTimeResponse(restClientMock, initialReferenceTime);
+			const referenceTimeSynchronizer = await ReferenceTimeSynchronizer.createInitializedWithRESTClient(
+				restClientMock,
 			);
 
 			const subscriber = jest.fn();
@@ -45,8 +44,10 @@ describe('The reference time synchronizer', () => {
 
 			// 15s passed and server and client are out of sync by 230ms.
 			const outOfSyncMilliseconds = 230;
-			scheduleReferenceTimeResponse(connectionMock, 16_337 + outOfSyncMilliseconds, 15_000, 16_000);
-			await timeMock.advanceTimeByMilliseconds(15_000);
+			const responseReferenceTime =
+				ReferenceTimeSynchronizer.UPDATE_INTERVAL_MILLISECONDS + initialReferenceTime + outOfSyncMilliseconds;
+			scheduleReferenceTimeResponse(restClientMock, responseReferenceTime, timeMock, 1_000);
+			await timeMock.advanceTimeByMilliseconds(ReferenceTimeSynchronizer.UPDATE_INTERVAL_MILLISECONDS);
 
 			expect(setInterval).toHaveBeenCalledTimes(1);
 			expect(subscriber).toHaveBeenCalledWith(outOfSyncMilliseconds);
@@ -55,18 +56,20 @@ describe('The reference time synchronizer', () => {
 
 	it('should not inform its subscriber if the offset stays the same', async () => {
 		await TimeMock.run(async (timeMock: TimeMock) => {
-			const connectionMock = mock<Connection>();
-			scheduleReferenceTimeResponse(connectionMock, 1337, 0, 1000);
-			const referenceTimeSynchronizer = await ReferenceTimeSynchronizer.createInitializedWithConnection(
-				connectionMock,
+			const initialReferenceTime = 1337;
+			const restClientMock = mock<RESTClient>();
+			scheduleReferenceTimeResponse(restClientMock, initialReferenceTime, timeMock, 0);
+			const referenceTimeSynchronizer = await ReferenceTimeSynchronizer.createInitializedWithRESTClient(
+				restClientMock,
 			);
 
 			const subscriber = jest.fn();
 			referenceTimeSynchronizer.start(subscriber);
 
 			// 15s passed and server and client are in sync.
-			scheduleReferenceTimeResponse(connectionMock, 16_337, 15_000, 16_000);
-			await timeMock.advanceTimeByMilliseconds(15_000);
+			const responseReferenceTime = ReferenceTimeSynchronizer.UPDATE_INTERVAL_MILLISECONDS + initialReferenceTime;
+			scheduleReferenceTimeResponse(restClientMock, responseReferenceTime, timeMock, 1_000);
+			await timeMock.advanceTimeByMilliseconds(ReferenceTimeSynchronizer.UPDATE_INTERVAL_MILLISECONDS);
 
 			expect(setInterval).toHaveBeenCalledTimes(1);
 			expect(subscriber).not.toHaveBeenCalled();
@@ -75,21 +78,19 @@ describe('The reference time synchronizer', () => {
 });
 
 function scheduleReferenceTimeResponse(
-	mock: ConnectionMock,
+	restClient: RESTClientMock,
 	referenceTime: number,
-	sentAt: number,
-	receivedAt: number,
+	timeMock?: TimeMock,
+	pingMilliseconds = 0,
 ) {
-	mockReset(mock);
-	mock.performRequest.calledWith(isA(GetReferenceTimeRequest)).mockResolvedValueOnce(
-		new EnrichedResponse(
-			<ReferenceTimeMessage>{
-				type: SuccessMessageType.ReferenceTime,
-				milliseconds: referenceTime + (receivedAt - sentAt) / 2,
-			},
-			new ResponseMetadata(sentAt, receivedAt),
-		),
-	);
+	mockReset(restClient);
+	restClient.getReferenceTimeMilliseconds.mockImplementationOnce(async () => {
+		if (timeMock !== undefined) {
+			await timeMock?.advanceTimeByMilliseconds(pingMilliseconds);
+		}
+
+		return referenceTime + pingMilliseconds / 2;
+	});
 }
 
-type ConnectionMock = {performRequest: CalledWithMock<Promise<EnrichedResponse>, [ClientRequest]>} & Connection;
+type RESTClientMock = {getReferenceTimeMilliseconds: CalledWithMock<Promise<number>, []>} & RESTClient;

--- a/communityvi-frontend/tests/client/registration.spec.ts
+++ b/communityvi-frontend/tests/client/registration.spec.ts
@@ -1,13 +1,16 @@
 import Client from '$lib/client/client';
 import TestTransport from './helper/test_transport';
 import RegisteredClient from '$lib/client/registered_client';
+import {mock} from 'jest-mock-extended';
+import {RESTClient} from '$lib/client/RESTClient';
 
 describe('Client registrations', () => {
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	const empty = () => {};
 
 	const transport = new TestTransport();
-	const client = new Client(transport);
+	const restClient = mock<RESTClient>();
+	const client = new Client(transport, restClient);
 
 	it('registers a client', async () => {
 		const registeredClient = await client.register('Max', empty);

--- a/communityvi-frontend/tests/client/registration.spec.ts
+++ b/communityvi-frontend/tests/client/registration.spec.ts
@@ -2,7 +2,7 @@ import Client from '$lib/client/client';
 import TestTransport from './helper/test_transport';
 import RegisteredClient from '$lib/client/registered_client';
 import {mock} from 'jest-mock-extended';
-import {RESTClient} from '$lib/client/RESTClient';
+import {ReferenceTimeResponse, RESTClient} from '$lib/client/RESTClient';
 
 describe('Client registrations', () => {
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -10,7 +10,7 @@ describe('Client registrations', () => {
 
 	const transport = new TestTransport();
 	const restClient = mock<RESTClient>();
-	restClient.getReferenceTimeMilliseconds.mockImplementation(async () => 0);
+	restClient.getReferenceTimeMilliseconds.mockImplementation(async () => new ReferenceTimeResponse(0, 0, 0));
 	const client = new Client(transport, restClient);
 
 	it('registers a client', async () => {

--- a/communityvi-frontend/tests/client/registration.spec.ts
+++ b/communityvi-frontend/tests/client/registration.spec.ts
@@ -10,6 +10,7 @@ describe('Client registrations', () => {
 
 	const transport = new TestTransport();
 	const restClient = mock<RESTClient>();
+	restClient.getReferenceTimeMilliseconds.mockImplementation(async () => 0);
 	const client = new Client(transport, restClient);
 
 	it('registers a client', async () => {

--- a/communityvi-server/Cargo.lock
+++ b/communityvi-server/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.0",
+ "swagger-ui",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -1034,6 +1035,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils 5.1.0",
+ "shellexpand",
  "syn",
  "walkdir",
 ]
@@ -1270,6 +1272,17 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "swagger-ui"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a59ee5a3b7e7310ec7b20be06090c0ed3019590cfea6e99cb4d26c4c45cc2c"
+dependencies = [
+ "rust-embed 5.9.0",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "syn"

--- a/communityvi-server/Cargo.lock
+++ b/communityvi-server/Cargo.lock
@@ -67,6 +67,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +162,7 @@ dependencies = [
  "humantime-serde",
  "ignore",
  "js_int",
+ "lazy_static",
  "log",
  "mime",
  "mime_guess",
@@ -161,10 +171,12 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand",
- "rust-embed",
+ "rust-embed 5.9.0",
+ "rust-embed 6.3.0",
  "rweb",
  "serde",
  "serde_json",
+ "sha2 0.10.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -194,11 +206,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+dependencies = [
+ "block-buffer 0.10.0",
+ "crypto-common",
  "generic-array",
 ]
 
@@ -973,12 +1005,36 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rust-embed"
+version = "5.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe1fe6aac5d6bb9e1ffd81002340363272a7648234ec7bdfac5ee202cb65523"
+dependencies = [
+ "rust-embed-impl 5.9.0",
+ "rust-embed-utils 5.1.0",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40377bff8cceee81e28ddb73ac97f5c2856ce5522f0b260b763f434cdfae602"
 dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
+ "rust-embed-impl 6.2.0",
+ "rust-embed-utils 7.1.0",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "5.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed91c41c42ef7bf687384439c312e75e0da9c149b0390889b94de3c7d9d9e66"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils 5.1.0",
+ "syn",
  "walkdir",
 ]
 
@@ -990,9 +1046,18 @@ checksum = "94e763e24ba2bf0c72bc6be883f967f794a019fafd1b86ba1daff9c91a7edd30"
 dependencies = [
  "proc-macro2",
  "quote",
- "rust-embed-utils",
+ "rust-embed-utils 7.1.0",
  "shellexpand",
  "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a512219132473ab0a77b52077059f1c47ce4af7fbdc94503e9862a34422876d"
+dependencies = [
  "walkdir",
 ]
 
@@ -1002,7 +1067,7 @@ version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad22c7226e4829104deab21df575e995bfbc4adfad13a595e387477f238c1aec"
 dependencies = [
- "sha2",
+ "sha2 0.9.8",
  "walkdir",
 ]
 
@@ -1138,10 +1203,10 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -1151,11 +1216,22 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d964dd36bb15bcf2f2b35694c072feab74969a54f2bbeec7a2d725d2bdcb6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.1",
 ]
 
 [[package]]

--- a/communityvi-server/Cargo.lock
+++ b/communityvi-server/Cargo.lock
@@ -165,6 +165,7 @@ dependencies = [
  "rweb",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.16.1",

--- a/communityvi-server/Cargo.toml
+++ b/communityvi-server/Cargo.toml
@@ -16,7 +16,7 @@ governor = { version = "0.4", default-features = false, features = ["std", "jitt
 hex = '0.4'
 humantime-serde = "1.0"
 js_int = {git = "https://github.com/ruma/js_int", branch = "main", features = ["serde", "float_deserialize"]}
-lazy_static = "1"
+lazy_static = {version = "1", optional = true}
 log = "0.4"
 mime = "0.3"
 mime_guess = {version = "2", default-features = false}
@@ -24,11 +24,12 @@ nonzero_ext = "0.3"
 parking_lot = "0.11"
 pin-project = "1"
 rust-embed = { version = "6", features = ["interpolate-folder-path"] }
-rust-embed5 = {package = "rust-embed", version = "5"}
+rust-embed5 = {package = "rust-embed", version = "5", optional = true}
 rweb = { version = "0.15", default-features = false, features = ["openapi", "websocket"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sha2 = "0.10"
+sha2 = {version = "0.10", optional = true}
+swagger-ui = {version = "0.1", optional = true}
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "parking_lot", "macros", "sync"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["sync"] }
@@ -46,5 +47,6 @@ npm_rs = "0.2"
 ignore = "0.4.18"
 
 [features]
-default = []
+default = ["api-docs"]
 bundle-frontend = []
+api-docs = ["lazy_static", "rust-embed5", "sha2", "swagger-ui"]

--- a/communityvi-server/Cargo.toml
+++ b/communityvi-server/Cargo.toml
@@ -26,6 +26,7 @@ rust-embed = { version = "6", features = ["interpolate-folder-path"] }
 rweb = { version = "0.15", default-features = false, features = ["openapi", "websocket"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "parking_lot", "macros", "sync"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["sync"] }
 tokio-tungstenite = "0.16"

--- a/communityvi-server/Cargo.toml
+++ b/communityvi-server/Cargo.toml
@@ -16,6 +16,7 @@ governor = { version = "0.4", default-features = false, features = ["std", "jitt
 hex = '0.4'
 humantime-serde = "1.0"
 js_int = {git = "https://github.com/ruma/js_int", branch = "main", features = ["serde", "float_deserialize"]}
+lazy_static = "1"
 log = "0.4"
 mime = "0.3"
 mime_guess = {version = "2", default-features = false}
@@ -23,9 +24,11 @@ nonzero_ext = "0.3"
 parking_lot = "0.11"
 pin-project = "1"
 rust-embed = { version = "6", features = ["interpolate-folder-path"] }
+rust-embed5 = {package = "rust-embed", version = "5"}
 rweb = { version = "0.15", default-features = false, features = ["openapi", "websocket"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "parking_lot", "macros", "sync"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["sync"] }

--- a/communityvi-server/src/configuration.rs
+++ b/communityvi-server/src/configuration.rs
@@ -1,8 +1,8 @@
 use serde::Deserialize;
-use std::fmt::{Display, Formatter};
 use std::fs::read_to_string;
 use std::net::SocketAddr;
 use std::path::Path;
+use thiserror::Error;
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Configuration {
@@ -31,33 +31,12 @@ impl TryFrom<&str> for Configuration {
 	}
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ConfigurationError {
-	DeserializationError(String),
-	IoError(String),
-}
-
-impl Display for ConfigurationError {
-	fn fmt(&self, formatter: &mut Formatter) -> std::fmt::Result {
-		match self {
-			ConfigurationError::DeserializationError(message) => {
-				write!(formatter, "Failed to deserialize with error: {}", message)
-			}
-			ConfigurationError::IoError(message) => write!(formatter, "IO operation failed: {}", message),
-		}
-	}
-}
-
-impl From<std::io::Error> for ConfigurationError {
-	fn from(io_error: std::io::Error) -> Self {
-		ConfigurationError::IoError(io_error.to_string())
-	}
-}
-
-impl From<toml::de::Error> for ConfigurationError {
-	fn from(toml_error: toml::de::Error) -> Self {
-		ConfigurationError::DeserializationError(toml_error.to_string())
-	}
+	#[error("Failed to deserialize with error: {0}")]
+	DeserializationError(#[from] toml::de::Error),
+	#[error("IO operation failed: {0}")]
+	IoError(#[from] std::io::Error),
 }
 
 // See https://serde.rs/custom-date-format.html

--- a/communityvi-server/src/context.rs
+++ b/communityvi-server/src/context.rs
@@ -1,10 +1,12 @@
 use crate::configuration::Configuration;
+use crate::reference_time::ReferenceTimer;
 use crate::utils::time_source::TimeSource;
 
 #[derive(Clone)]
 pub struct ApplicationContext {
 	pub configuration: Configuration,
 	pub time_source: TimeSource,
+	pub reference_timer: ReferenceTimer,
 }
 
 impl ApplicationContext {
@@ -12,6 +14,7 @@ impl ApplicationContext {
 		Self {
 			configuration,
 			time_source,
+			reference_timer: ReferenceTimer::default(),
 		}
 	}
 }

--- a/communityvi-server/src/error.rs
+++ b/communityvi-server/src/error.rs
@@ -1,34 +1,10 @@
 use crate::configuration::ConfigurationError;
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum CommunityviError {
-	ConfigurationError(ConfigurationError),
-	CommandlineError(String),
-}
-
-impl Display for CommunityviError {
-	fn fmt(&self, formatter: &mut Formatter) -> std::fmt::Result {
-		match self {
-			CommunityviError::ConfigurationError(error) => write!(formatter, "Failed to load configuration: {}", error),
-			CommunityviError::CommandlineError(message) => {
-				write!(formatter, "Failed to parse commandline: {}", message)
-			}
-		}
-	}
-}
-
-impl Error for CommunityviError {}
-
-impl From<ConfigurationError> for CommunityviError {
-	fn from(configuration_error: ConfigurationError) -> Self {
-		CommunityviError::ConfigurationError(configuration_error)
-	}
-}
-
-impl From<clap::Error> for CommunityviError {
-	fn from(clap_error: clap::Error) -> Self {
-		CommunityviError::CommandlineError(clap_error.to_string())
-	}
+	#[error("Failed to load configuration: {0}")]
+	ConfigurationError(#[from] ConfigurationError),
+	#[error("Failed to parse commandline: {0}")]
+	CommandlineError(#[from] clap::Error),
 }

--- a/communityvi-server/src/main.rs
+++ b/communityvi-server/src/main.rs
@@ -20,6 +20,7 @@ mod context;
 mod error;
 mod lifecycle;
 mod message;
+mod reference_time;
 mod room;
 mod server;
 #[cfg(test)]

--- a/communityvi-server/src/message.rs
+++ b/communityvi-server/src/message.rs
@@ -1,32 +1,15 @@
-use std::error::Error;
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::Debug;
+use thiserror::Error;
 
 pub mod client_request;
 pub mod outgoing;
 
 pub type WebSocketMessage = tokio_tungstenite::tungstenite::Message;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum MessageError {
+	#[error("Failed to deserialize message with error: '{}'; Message was '{}'", .error, .json)]
 	DeserializationFailed { error: String, json: String },
+	#[error("Wrong websocket message type. Epected text, got: {0:?}")]
 	WrongMessageType(WebSocketMessage),
 }
-
-impl Display for MessageError {
-	fn fmt(&self, formatter: &mut Formatter) -> Result<(), std::fmt::Error> {
-		match self {
-			MessageError::DeserializationFailed { error, json } => write!(
-				formatter,
-				"Failed to deserialize message with error: '{}'; Message was '{}'",
-				error, json
-			),
-			MessageError::WrongMessageType(message) => write!(
-				formatter,
-				"Wrong websocket message type. Expected text, got: {:?}",
-				message
-			),
-		}
-	}
-}
-
-impl Error for MessageError {}

--- a/communityvi-server/src/message/client_request.rs
+++ b/communityvi-server/src/message/client_request.rs
@@ -21,7 +21,6 @@ pub struct ClientRequestWithId {
 pub enum ClientRequest {
 	Register(RegisterRequest),
 	Chat(ChatRequest),
-	GetReferenceTime,
 	InsertMedium(InsertMediumRequest),
 	Play(PlayRequest),
 	Pause(PauseRequest),
@@ -33,7 +32,6 @@ impl ClientRequest {
 		match self {
 			Register(_) => "Register",
 			Chat(_) => "Chat",
-			GetReferenceTime => "GetReferenceTime",
 			InsertMedium(_) => "InsertMedium",
 			Play(_) => "Play",
 			Pause(_) => "Pause",
@@ -228,18 +226,6 @@ mod test {
 		let deserialized_register_request: ClientRequestWithId =
 			serde_json::from_str(&json).expect("Failed to deserialize Register request from JSON");
 		assert_eq!(register_request, deserialized_register_request);
-	}
-
-	#[test]
-	fn get_reference_time_request_should_serialize_and_deserialize() {
-		let get_reference_time_request = ClientRequest::GetReferenceTime.with_id(uint!(42));
-		let json = serde_json::to_string(&get_reference_time_request)
-			.expect("Failed to serialize GetReferenceTime request to JSON");
-		assert_eq!(r#"{"request_id":42,"type":"get_reference_time"}"#, json);
-
-		let deserialized_get_reference_time_request: ClientRequestWithId =
-			serde_json::from_str(&json).expect("Failed to deserialize GetReferenceTime request from JSON");
-		assert_eq!(get_reference_time_request, deserialized_get_reference_time_request);
 	}
 
 	#[test]

--- a/communityvi-server/src/message/outgoing/success_message.rs
+++ b/communityvi-server/src/message/outgoing/success_message.rs
@@ -15,9 +15,6 @@ pub enum SuccessMessage {
 		clients: Vec<ClientResponse>,
 		current_medium: VersionedMediumResponse,
 	},
-	ReferenceTime {
-		milliseconds: UInt,
-	},
 	Success,
 }
 
@@ -169,20 +166,6 @@ mod test {
 		let deserialized_hello_response: SuccessMessage =
 			serde_json::from_str(&json).expect("Failed to deserialize Hello response from JSON");
 		assert_eq!(hello_response, deserialized_hello_response);
-	}
-
-	#[test]
-	fn reference_time_response_should_serialize_and_deserialize() {
-		let reference_time_response = SuccessMessage::ReferenceTime {
-			milliseconds: uint!(1337),
-		};
-		let json = serde_json::to_string(&reference_time_response)
-			.expect("Failed to serialize ReferenceTime response to JSON");
-		assert_eq!(r#"{"type":"reference_time","milliseconds":1337}"#, json);
-
-		let deserialized_reference_time_response: SuccessMessage =
-			serde_json::from_str(&json).expect("Failed to deserialize ReferenceTime response from JSON");
-		assert_eq!(reference_time_response, deserialized_reference_time_response);
 	}
 
 	#[test]

--- a/communityvi-server/src/reference_time.rs
+++ b/communityvi-server/src/reference_time.rs
@@ -1,0 +1,63 @@
+use js_int::UInt;
+use std::time::Instant;
+
+#[derive(Clone, Copy)]
+pub struct ReferenceTimer(Instant);
+
+impl ReferenceTimer {
+	pub fn reference_time(&self) -> std::time::Duration {
+		self.0.elapsed()
+	}
+
+	pub fn reference_time_milliseconds(&self) -> UInt {
+		#[allow(clippy::cast_possible_truncation)]
+		let milliseconds = self.reference_time().as_millis() as u64;
+		UInt::try_from(milliseconds)
+			.expect("More milliseconds than can be represented by IEEE 754 doubles. This shouldn't happen unless the server was running for more than about 285000 years.")
+	}
+}
+
+impl Default for ReferenceTimer {
+	fn default() -> Self {
+		Self(Instant::now())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use std::thread::sleep;
+	use std::time::Duration;
+
+	#[test]
+	fn reference_timer_should_time_the_reference_time() {
+		let reference_timer = ReferenceTimer::default();
+
+		let initial_time = reference_timer.reference_time();
+		sleep(Duration::from_millis(1));
+		let final_time = reference_timer.reference_time();
+
+		let elapsed = final_time - initial_time;
+		assert!(
+			(1..10).contains(&elapsed.as_millis()),
+			"Expected the elapsed time to be between 1ms and 10ms, but was: {:?}",
+			elapsed
+		);
+	}
+
+	#[test]
+	fn reference_timer_should_time_reference_time_milliseconds() {
+		let reference_timer = ReferenceTimer::default();
+
+		let initial_milliseconds = reference_timer.reference_time_milliseconds();
+		sleep(Duration::from_millis(1));
+		let final_milliseconds = reference_timer.reference_time_milliseconds();
+
+		let elapsed = final_milliseconds - initial_milliseconds;
+		assert!(
+			(1..10).contains(&u64::from(elapsed)),
+			"Expected the elapsed time to be between 1ms and 10ms, but was: {}ms",
+			elapsed
+		);
+	}
+}

--- a/communityvi-server/src/room/client_id_sequence.rs
+++ b/communityvi-server/src/room/client_id_sequence.rs
@@ -1,15 +1,15 @@
 use crate::room::client_id::ClientId;
 use js_int::UInt;
-use std::ops::Range;
+use std::ops::RangeInclusive;
 
 pub struct ClientIdSequence {
-	id_pool: Range<u64>,
+	id_pool: RangeInclusive<u64>,
 }
 
 impl Default for ClientIdSequence {
 	fn default() -> Self {
 		Self {
-			id_pool: UInt::MIN.into()..UInt::MAX.into(),
+			id_pool: UInt::MIN.into()..=UInt::MAX.into(),
 		}
 	}
 }
@@ -17,12 +17,8 @@ impl Default for ClientIdSequence {
 impl ClientIdSequence {
 	pub fn next(&mut self) -> ClientId {
 		ClientId::from(
-			UInt::try_from(
-				self.id_pool
-					.next()
-					.expect("This only happens if 9007199254740991 ClientIDs are created."),
-			)
-			.unwrap_or_else(|_| unreachable!()),
+			UInt::try_from(self.id_pool.next().expect("Ran out of available ClientIds."))
+				.unwrap_or_else(|_| unreachable!()),
 		)
 	}
 }

--- a/communityvi-server/src/room/error.rs
+++ b/communityvi-server/src/room/error.rs
@@ -1,23 +1,13 @@
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use thiserror::Error;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum RoomError {
+	#[error("Name was empty or whitespace-only.")]
 	EmptyClientName,
+	#[error("Client name is already in use.")]
 	ClientNameAlreadyInUse,
+	#[error("Client name is too long. (>256 bytes UTF-8)")]
 	ClientNameTooLong,
+	#[error("Can't join, room is already full.")]
 	RoomFull,
 }
-
-impl Display for RoomError {
-	fn fmt(&self, formatter: &mut Formatter) -> std::fmt::Result {
-		match self {
-			RoomError::EmptyClientName => formatter.write_str("Name was empty or whitespace-only."),
-			RoomError::ClientNameAlreadyInUse => formatter.write_str("Client name is already in use."),
-			RoomError::ClientNameTooLong => formatter.write_str("Client name is too long. (>256 bytes UTF-8)"),
-			RoomError::RoomFull => formatter.write_str("Can't join, room is already full."),
-		}
-	}
-}
-
-impl Error for RoomError {}

--- a/communityvi-server/src/server.rs
+++ b/communityvi-server/src/server.rs
@@ -74,20 +74,12 @@ fn websocket_filter(application_context: ApplicationContext, room: Room) -> Boxe
 fn bundled_frontend_filter() -> BoxedFilter<(Response<Body>,)> {
 	use crate::server::file_bundle::BundledFileHandler;
 	use rust_embed::RustEmbed;
-	use rweb::filters;
-	use rweb::http::HeaderMap;
-	use rweb::path::Tail;
 
 	#[derive(RustEmbed)]
 	#[folder = "$CARGO_MANIFEST_DIR/../communityvi-frontend/build"]
 	struct FrontendBundle;
 
-	let bundled_file_handler = BundledFileHandler::new::<FrontendBundle>();
-
-	filters::path::tail()
-		.and(filters::header::headers_cloned())
-		.map(move |path: Tail, headers: HeaderMap| bundled_file_handler.request(path.as_str(), &headers))
-		.boxed()
+	BundledFileHandler::new::<FrontendBundle>().into_rweb_filter().boxed()
 }
 
 #[cfg(not(feature = "bundle-frontend"))]

--- a/communityvi-server/src/server.rs
+++ b/communityvi-server/src/server.rs
@@ -29,7 +29,7 @@ pub async fn run_server(application_context: ApplicationContext) {
 pub fn create_filter(application_context: ApplicationContext, room: Room) -> BoxedFilter<(impl Reply,)> {
 	let reference_timer = application_context.reference_timer;
 	websocket_filter(application_context, room)
-		.or(rweb::path("api").and(rest_api::rest_api(reference_timer)))
+		.or(rest_api::rest_api(reference_timer))
 		.or(bundled_frontend_filter())
 		.boxed()
 }

--- a/communityvi-server/src/server.rs
+++ b/communityvi-server/src/server.rs
@@ -15,6 +15,7 @@ use rweb::{Filter, Reply};
 use std::future::ready;
 
 mod file_bundle;
+mod rest_api;
 
 pub async fn run_server(application_context: ApplicationContext) {
 	let room = Room::new(application_context.configuration.room_size_limit);
@@ -23,7 +24,8 @@ pub async fn run_server(application_context: ApplicationContext) {
 }
 
 pub fn create_filter(application_context: ApplicationContext, room: Room) -> BoxedFilter<(impl Reply,)> {
-	websocket_filter(application_context, room)
+	websocket_filter(application_context, room.clone())
+		.or(rweb::path("api").and(rest_api::rest_api(room)))
 		.or(bundled_frontend_filter())
 		.boxed()
 }

--- a/communityvi-server/src/server/rest_api.rs
+++ b/communityvi-server/src/server/rest_api.rs
@@ -1,16 +1,14 @@
-#![allow(clippy::needless_pass_by_value)] // #[data] requires owned values
-use crate::room::Room;
+use crate::reference_time::ReferenceTimer;
 use rweb::filters::BoxedFilter;
 use rweb::{get, openapi, Filter, Json, Reply};
 
-pub fn rest_api(room: Room) -> BoxedFilter<(impl Reply,)> {
-	let (_spec, filter) = openapi::spec().build(move || reference_time_milliseconds(room));
+pub fn rest_api(reference_timer: ReferenceTimer) -> BoxedFilter<(impl Reply,)> {
+	let (_spec, filter) = openapi::spec().build(move || reference_time_milliseconds(reference_timer));
 	filter.boxed()
 }
 
 #[get("/reference_time_milliseconds")]
-fn reference_time_milliseconds(#[data] room: Room) -> Json<u64> {
-	#[allow(clippy::cast_possible_truncation)]
-	let milliseconds = room.current_reference_time().as_millis() as u64;
+fn reference_time_milliseconds(#[data] reference_timer: ReferenceTimer) -> Json<u64> {
+	let milliseconds = u64::from(reference_timer.reference_time_milliseconds());
 	Json::from(milliseconds)
 }

--- a/communityvi-server/src/server/rest_api.rs
+++ b/communityvi-server/src/server/rest_api.rs
@@ -6,8 +6,9 @@ use rweb::{get, openapi, router, Filter, Json, Reply};
 mod api_docs;
 
 pub fn rest_api(reference_timer: ReferenceTimer) -> BoxedFilter<(impl Reply,)> {
-	let (spec, filter) = openapi::spec().build(move || api(reference_timer));
-	filter.or(openapi_filter(spec)).boxed()
+	let (spec, api) = openapi::spec().build(move || api(reference_timer));
+	let cors = rweb::cors().allow_any_origin().build();
+	api.with(cors).or(openapi_filter(spec)).boxed()
 }
 
 pub fn openapi_filter(spec: openapi::Spec) -> BoxedFilter<(impl Reply,)> {

--- a/communityvi-server/src/server/rest_api.rs
+++ b/communityvi-server/src/server/rest_api.rs
@@ -1,0 +1,16 @@
+#![allow(clippy::needless_pass_by_value)] // #[data] requires owned values
+use crate::room::Room;
+use rweb::filters::BoxedFilter;
+use rweb::{get, openapi, Filter, Json, Reply};
+
+pub fn rest_api(room: Room) -> BoxedFilter<(impl Reply,)> {
+	let (_spec, filter) = openapi::spec().build(move || reference_time_milliseconds(room));
+	filter.boxed()
+}
+
+#[get("/reference_time_milliseconds")]
+fn reference_time_milliseconds(#[data] room: Room) -> Json<u64> {
+	#[allow(clippy::cast_possible_truncation)]
+	let milliseconds = room.current_reference_time().as_millis() as u64;
+	Json::from(milliseconds)
+}

--- a/communityvi-server/src/server/rest_api.rs
+++ b/communityvi-server/src/server/rest_api.rs
@@ -28,7 +28,7 @@ pub fn openapi_filter(spec: openapi::Spec) -> BoxedFilter<(impl Reply,)> {
 #[router("/api", services(reference_time_milliseconds))]
 fn api(#[data] _reference_timer: ReferenceTimer) {}
 
-#[get("/reference_time_milliseconds")]
+#[get("/reference-time-milliseconds")]
 fn reference_time_milliseconds(#[data] reference_timer: ReferenceTimer) -> Json<u64> {
 	let milliseconds = u64::from(reference_timer.reference_time_milliseconds());
 	Json::from(milliseconds)

--- a/communityvi-server/src/server/rest_api/api_docs.rs
+++ b/communityvi-server/src/server/rest_api/api_docs.rs
@@ -1,0 +1,79 @@
+use crate::server::file_bundle::BundledFileHandler;
+use crate::utils::rust_embed_adapter::RustEmbedAdapter;
+use rweb::filters::BoxedFilter;
+use rweb::Filter;
+use rweb::Reply;
+
+pub fn api_docs() -> BoxedFilter<(impl Reply,)> {
+	let swagger_ui_bundle = BundledFileHandler::new::<RustEmbedAdapter<swagger_ui::Assets>>();
+	rweb::path::end()
+		.or(rweb::path("index.html")) // NOTE: overrides the index.html in the swagger_ui_bundle
+		.map(|_| rweb::reply::html(INDEX_HTML))
+		.or(swagger_ui_bundle.into_rweb_filter().boxed())
+		.boxed()
+}
+
+// See https://github.com/swagger-api/swagger-ui/blob/8718d4b267921b00fd616755760cc21cf4953ba9/dist/index.html
+// But with modified configuration and `./` replaced with `/api/docs`
+const INDEX_HTML: &str = r#"
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link rel="stylesheet" type="text/css" href="/api/docs/swagger-ui.css" />
+    <link rel="icon" type="image/png" href="/api/docs/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="/api/docs/favicon-16x16.png" sizes="16x16" />
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
+
+      body
+      {
+        margin:0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+
+    <script src="/api/docs/swagger-ui-bundle.js" charset="UTF-8"> </script>
+    <script src="/api/docs/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+    <script>
+    window.onload = function() {
+      // Begin Swagger UI call region
+      const ui = SwaggerUIBundle({
+        url: "/api/openapi.json",
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      });
+      // End Swagger UI call region
+
+      window.ui = ui;
+    };
+  </script>
+  </body>
+</html>
+"#;

--- a/communityvi-server/src/server_tests.rs
+++ b/communityvi-server/src/server_tests.rs
@@ -6,6 +6,7 @@ use crate::message::outgoing::broadcast_message::{
 };
 use crate::message::outgoing::error_message::{ErrorMessage, ErrorMessageType};
 use crate::message::outgoing::success_message::SuccessMessage;
+use crate::reference_time::ReferenceTimer;
 use crate::room::client_id::ClientId;
 use crate::room::Room;
 use crate::server::create_filter;
@@ -183,7 +184,7 @@ async fn websocket_test_client(filter: &BoxedFilter<(impl Reply + 'static,)>) ->
 }
 
 pub(self) fn test_filter() -> BoxedFilter<(impl Reply,)> {
-	let room = Room::new(10);
+	let room = Room::new(ReferenceTimer::default(), 10);
 	let configuration = Configuration {
 		address: "127.0.0.1:8000".parse().unwrap(),
 		log_filters: "".to_string(),

--- a/communityvi-server/src/server_tests.rs
+++ b/communityvi-server/src/server_tests.rs
@@ -16,6 +16,8 @@ use rweb::filters::BoxedFilter;
 use rweb::Reply;
 use tokio_tungstenite::tungstenite;
 
+mod rest_api;
+
 #[tokio::test]
 async fn should_respond_to_websocket_messages() {
 	let filter = test_filter();
@@ -180,7 +182,7 @@ async fn websocket_test_client(filter: &BoxedFilter<(impl Reply + 'static,)>) ->
 		.into()
 }
 
-fn test_filter() -> BoxedFilter<(impl Reply,)> {
+pub(self) fn test_filter() -> BoxedFilter<(impl Reply,)> {
 	let room = Room::new(10);
 	let configuration = Configuration {
 		address: "127.0.0.1:8000".parse().unwrap(),

--- a/communityvi-server/src/server_tests/rest_api.rs
+++ b/communityvi-server/src/server_tests/rest_api.rs
@@ -1,6 +1,10 @@
 use crate::server_tests::test_filter;
 use js_int::{uint, UInt};
 use rweb::http::StatusCode;
+use serde::Deserialize;
+
+#[cfg(feature = "api-docs")]
+mod api_docs;
 
 #[tokio::test]
 async fn should_return_reference_time() {
@@ -17,4 +21,27 @@ async fn should_return_reference_time() {
 	assert_eq!(status_code, StatusCode::OK);
 	assert!(content >= uint!(0));
 	assert!(content <= uint!(1_000));
+}
+
+#[tokio::test]
+async fn should_provide_openapi_json() {
+	let filter = test_filter();
+	let response = rweb::test::request()
+		.method("GET")
+		.path("/api/openapi.json")
+		.reply(&filter)
+		.await;
+
+	let status_code = response.status();
+
+	// custom struct since rweb::openapi::Spec can't be deserialized from it's own serialization ...
+	#[derive(Deserialize)]
+	struct OpenApi {
+		openapi: String,
+	}
+	let specification = serde_json::from_slice::<OpenApi>(response.body())
+		.expect("Failed to deserialize OpenAPI specification from JSON");
+
+	assert_eq!(status_code, StatusCode::OK);
+	assert!(specification.openapi.starts_with("3."));
 }

--- a/communityvi-server/src/server_tests/rest_api.rs
+++ b/communityvi-server/src/server_tests/rest_api.rs
@@ -1,0 +1,20 @@
+use crate::server_tests::test_filter;
+use js_int::{uint, UInt};
+use rweb::http::StatusCode;
+
+#[tokio::test]
+async fn should_return_reference_time() {
+	let filter = test_filter();
+	let response = rweb::test::request()
+		.method("GET")
+		.path("/api/reference_time_milliseconds")
+		.reply(&filter)
+		.await;
+
+	let status_code = response.status();
+	let content = serde_json::from_slice::<UInt>(response.body()).expect("Failed to parse reference time JSON");
+
+	assert_eq!(status_code, StatusCode::OK);
+	assert!(content >= uint!(0));
+	assert!(content <= uint!(1_000));
+}

--- a/communityvi-server/src/server_tests/rest_api.rs
+++ b/communityvi-server/src/server_tests/rest_api.rs
@@ -11,7 +11,7 @@ async fn should_return_reference_time() {
 	let filter = test_filter();
 	let response = rweb::test::request()
 		.method("GET")
-		.path("/api/reference_time_milliseconds")
+		.path("/api/reference-time-milliseconds")
 		.reply(&filter)
 		.await;
 

--- a/communityvi-server/src/server_tests/rest_api/api_docs.rs
+++ b/communityvi-server/src/server_tests/rest_api/api_docs.rs
@@ -1,0 +1,35 @@
+use crate::server_tests::test_filter;
+use rweb::http::StatusCode;
+
+#[tokio::test]
+async fn should_display_overriden_swagger_ui_index_html() {
+	let filter = test_filter();
+	let aliases = ["/api/docs", "/api/docs/"];
+
+	let response_to_explicit_path = rweb::test::request()
+		.method("GET")
+		.path("/api/docs/index.html")
+		.reply(&filter)
+		.await;
+	assert_eq!(response_to_explicit_path.status(), StatusCode::OK);
+	let response_string = String::from_utf8_lossy(response_to_explicit_path.body());
+	assert!(response_string.contains("SwaggerUIBundle"));
+	// make sure it's not the bundled index file
+	assert!(response_string.contains("/api/openapi.json"));
+
+	for alias in aliases {
+		let response = rweb::test::request().method("GET").path(alias).reply(&filter).await;
+		assert_eq!(
+			response.status(),
+			response_to_explicit_path.status(),
+			"Status for alias '{}' was different from the explicit path.",
+			alias
+		);
+		assert_eq!(
+			response.body(),
+			response_to_explicit_path.body(),
+			"Response for alias '{}' was different from the explicit path.",
+			alias
+		);
+	}
+}

--- a/communityvi-server/src/utils.rs
+++ b/communityvi-server/src/utils.rs
@@ -2,6 +2,7 @@
 pub mod backtrace_disabler;
 #[cfg(test)]
 pub mod fake_message_sender;
+pub mod rust_embed_adapter;
 #[cfg(test)]
 pub mod test_client;
 pub mod time_source;

--- a/communityvi-server/src/utils.rs
+++ b/communityvi-server/src/utils.rs
@@ -2,6 +2,7 @@
 pub mod backtrace_disabler;
 #[cfg(test)]
 pub mod fake_message_sender;
+#[cfg(feature = "api-docs")]
 pub mod rust_embed_adapter;
 #[cfg(test)]
 pub mod test_client;

--- a/communityvi-server/src/utils/rust_embed_adapter.rs
+++ b/communityvi-server/src/utils/rust_embed_adapter.rs
@@ -1,0 +1,60 @@
+use lazy_static::lazy_static;
+use parking_lot::RwLock;
+use rust_embed::{EmbeddedFile, Filenames, Metadata, RustEmbed};
+use rust_embed5::{Filenames as Filenames5, RustEmbed as RustEmbed5};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
+
+pub struct RustEmbedAdapter<T>(PhantomData<T>);
+
+impl<T> RustEmbed for RustEmbedAdapter<T>
+where
+	T: RustEmbed5,
+{
+	fn get(file_path: &str) -> Option<EmbeddedFile> {
+		T::get(file_path).map(|data| {
+			let hash = cached_sha256(file_path.as_ref(), &data);
+			EmbeddedFile {
+				data,
+				// NOTE: This relies on unstable API but we'll have to live with that for now
+				// since there is no other way to adapt the old RustEmbed to the new one.
+				metadata: Metadata::__rust_embed_new(hash, None),
+			}
+		})
+	}
+
+	fn iter() -> Filenames {
+		#[cfg(not(debug_assertions))]
+		{
+			let Filenames5::Embedded(iterator) = T::iter();
+			Filenames::Embedded(iterator)
+		}
+
+		#[cfg(debug_assertions)]
+		{
+			let Filenames5::Dynamic(iterator) = T::iter();
+			Filenames::Dynamic(iterator)
+		}
+	}
+}
+
+fn cached_sha256(path: &Path, bytes: &[u8]) -> [u8; 32] {
+	lazy_static! {
+		static ref CACHE: RwLock<HashMap<PathBuf, [u8; 32]>> = RwLock::default();
+	};
+
+	{
+		let cache = CACHE.read();
+		if let Some(&hash) = cache.get(path) {
+			return hash;
+		}
+	}
+
+	*CACHE.write().entry(path.into()).or_insert_with(|| {
+		let mut hasher = Sha256::default();
+		hasher.update(bytes);
+		hasher.finalize().into()
+	})
+}


### PR DESCRIPTION
This adds the first REST API endpoint `/api/reference-time-milliseconds` and all the machinery around it:
* REST client in the frontend
* Automatically generated OpenAPI specification
* Bundled Swagger-UI