### PR TITLE
Remove rust-embed 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
     allow:
       - dependency-type: "all"
 
+  - package-ecosystem: "npm"
+    directory: "/communityvi-server/swagger-ui"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    allow:
+      - dependency-type: "all"
+
   - package-ecosystem: "cargo"
     directory: "/communityvi-server/"
     schedule:

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -75,5 +75,5 @@ jobs:
         run: cargo build --all
       - name: Run tests
         run: cargo test --all
-      - name: Run tests with bundled frontend
-        run: cargo test --all --features bundle-frontend
+      - name: Run tests with bundled frontend and api-docs
+        run: cargo test --all --features bundle-frontend,api-docs

--- a/communityvi-server/Cargo.lock
+++ b/communityvi-server/Cargo.lock
@@ -181,13 +181,11 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand",
- "rust-embed 5.9.0",
- "rust-embed 6.4.0",
+ "rust-embed",
  "rweb",
  "serde",
  "serde_json",
  "sha2 0.10.2",
- "swagger-ui",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -980,37 +978,12 @@ checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "rust-embed"
-version = "5.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe1fe6aac5d6bb9e1ffd81002340363272a7648234ec7bdfac5ee202cb65523"
-dependencies = [
- "rust-embed-impl 5.9.0",
- "rust-embed-utils 5.1.0",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed"
 version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a17e5ac65b318f397182ae94e532da0ba56b88dd1200b774715d36c4943b1c3"
 dependencies = [
- "rust-embed-impl 6.2.0",
- "rust-embed-utils 7.2.0",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "5.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed91c41c42ef7bf687384439c312e75e0da9c149b0390889b94de3c7d9d9e66"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils 5.1.0",
- "shellexpand",
- "syn",
+ "rust-embed-impl",
+ "rust-embed-utils",
  "walkdir",
 ]
 
@@ -1022,18 +995,9 @@ checksum = "94e763e24ba2bf0c72bc6be883f967f794a019fafd1b86ba1daff9c91a7edd30"
 dependencies = [
  "proc-macro2",
  "quote",
- "rust-embed-utils 7.2.0",
+ "rust-embed-utils",
  "shellexpand",
  "syn",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a512219132473ab0a77b52077059f1c47ce4af7fbdc94503e9862a34422876d"
-dependencies = [
  "walkdir",
 ]
 
@@ -1263,17 +1227,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "swagger-ui"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a59ee5a3b7e7310ec7b20be06090c0ed3019590cfea6e99cb4d26c4c45cc2c"
-dependencies = [
- "rust-embed 5.9.0",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "syn"

--- a/communityvi-server/Cargo.toml
+++ b/communityvi-server/Cargo.toml
@@ -28,12 +28,10 @@ nonzero_ext = "0.3"
 parking_lot = "0.12"
 pin-project = "1"
 rust-embed = { version = "6", features = ["interpolate-folder-path"] }
-rust-embed5 = {package = "rust-embed", version = "5", optional = true}
 rweb = { version = "0.15", default-features = false, features = ["openapi", "websocket"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
-swagger-ui = {version = "0.1", optional = true}
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "parking_lot", "macros", "sync"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["sync"] }
@@ -52,6 +50,8 @@ npm_rs = "0.2"
 ignore = "0.4.18"
 
 [features]
-default = ["api-docs"]
+default = []
+# Bundle the JS frontend.
 bundle-frontend = []
-api-docs = ["rust-embed5", "swagger-ui"]
+# Bundle Swagger-UI
+api-docs = []

--- a/communityvi-server/src/server/file_bundle.rs
+++ b/communityvi-server/src/server/file_bundle.rs
@@ -31,14 +31,6 @@ impl BundledFileHandler {
 		}
 	}
 
-	#[cfg(feature = "api-docs")]
-	/// Creates a new [`BundledFileHandler`] from a [`rust_embed5::RustEmbed`] asset type, erasing the type in the process.
-	pub fn new_with_rust_embed5<Bundle: rust_embed5::RustEmbed>() -> Self {
-		Self {
-			file_getter: Arc::new(|path| Bundle::get(path).map(|content| BundledFile::new(path, content))),
-		}
-	}
-
 	pub fn with_override(self, file: BundledFile) -> Self {
 		let Self { file_getter } = self;
 

--- a/communityvi-server/src/server/rest_api/api_docs.rs
+++ b/communityvi-server/src/server/rest_api/api_docs.rs
@@ -1,11 +1,16 @@
 use crate::server::file_bundle::{BundledFile, BundledFileHandler};
+use rust_embed::RustEmbed;
 use rweb::filters::BoxedFilter;
 use rweb::Filter;
 use rweb::Reply;
 use std::borrow::Cow;
 
 pub fn api_docs() -> BoxedFilter<(impl Reply,)> {
-	BundledFileHandler::new_with_rust_embed5::<swagger_ui::Assets>()
+	#[derive(RustEmbed)]
+	#[folder = "$CARGO_MANIFEST_DIR/swagger-ui/node_modules/swagger-ui-dist"]
+	struct SwaggerUi;
+
+	BundledFileHandler::new_with_rust_embed::<SwaggerUi>()
 		.with_override(BundledFile::new("index.html", Cow::Borrowed(INDEX_HTML.as_bytes())))
 		.into_rweb_filter()
 		.boxed()

--- a/communityvi-server/src/server_tests/rest_api/api_docs.rs
+++ b/communityvi-server/src/server_tests/rest_api/api_docs.rs
@@ -43,7 +43,8 @@ async fn should_serve_overriden_swagger_ui_index_html() {
 async fn should_serve_bundled_swagger_ui() {
 	let http_client = start_test_server();
 
-	for filename in swagger_ui::Assets::iter().filter(|filename| filename != "index.html") {
+	// sample some of the files
+	for filename in ["index.html", "swagger-ui.js", "LICENSE"] {
 		let mut response = http_client
 			.get(&format!("/api/docs/{filename}"))
 			.send()
@@ -52,10 +53,6 @@ async fn should_serve_bundled_swagger_ui() {
 
 		assert_eq!(response.status(), StatusCode::OK, "Missing file '{filename}'");
 		let content = response.content().await.expect("Failed to get response bytes.");
-		assert_eq!(
-			&content,
-			swagger_ui::Assets::get(&filename).unwrap().as_ref(),
-			"File '{filename}' has an incorrect content.",
-		);
+		assert!(!content.is_empty(), "File '{filename}' is empty.");
 	}
 }

--- a/communityvi-server/swagger-ui/.gitignore
+++ b/communityvi-server/swagger-ui/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/communityvi-server/swagger-ui/package-lock.json
+++ b/communityvi-server/swagger-ui/package-lock.json
@@ -1,0 +1,28 @@
+{
+	"name": "communityvi-swagger-ui-bundle",
+	"version": "0.0.1",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "communityvi-swagger-ui-bundle",
+			"version": "0.0.1",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"swagger-ui-dist": "^4.12.0"
+			}
+		},
+		"node_modules/swagger-ui-dist": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.12.0.tgz",
+			"integrity": "sha512-B0Iy2ueXtbByE6OOyHTi3lFQkpPi/L7kFOKFeKTr44za7dJIELa9kzaca6GkndCgpK1QTjArnoXG+aUy0XQp1w=="
+		}
+	},
+	"dependencies": {
+		"swagger-ui-dist": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.12.0.tgz",
+			"integrity": "sha512-B0Iy2ueXtbByE6OOyHTi3lFQkpPi/L7kFOKFeKTr44za7dJIELa9kzaca6GkndCgpK1QTjArnoXG+aUy0XQp1w=="
+		}
+	}
+}

--- a/communityvi-server/swagger-ui/package.json
+++ b/communityvi-server/swagger-ui/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "communityvi-swagger-ui-bundle",
+	"version": "0.0.1",
+	"description": "NPM package for bundling swagger-ui.",
+	"license": "Apache-2.0",
+	"dependencies": {
+		"swagger-ui-dist": "^4.12.0"
+	}
+}


### PR DESCRIPTION
It's annoying to have both `rust-embed` 5 and 6, and also `rust-embed` 5 has a vulnerability.

Unfortunately, this means we now need to bundle `swagger-ui` ourselves.

The way I'm doing it here is by creating a new `npm` package with `swagger-ui-dist` as it's dependency. When the `api-docs` feature is enabled, we can then run `npm install` in the `build.rs` and bundle `swagger-ui-dist` from `node_modules`.

I'm also adding the `swagger-ui` directory to Dependabot, so `swagger-ui` should get updated automatically.

Sadly the tests for the bundled swagger ui don't test everything anymore, but that should be fine given that the `BundledFileHandler` is already tested by itself.