### PR TITLE
Manually upgrade SvelteKit to next.399

### DIFF
--- a/communityvi-frontend/.svelte-kit/tsconfig.json
+++ b/communityvi-frontend/.svelte-kit/tsconfig.json
@@ -18,19 +18,21 @@
 		"preserveValueImports": true,
 		"lib": [
 			"esnext",
-			"DOM"
+			"DOM",
+			"DOM.Iterable"
 		],
 		"moduleResolution": "node",
 		"module": "esnext",
 		"target": "esnext"
 	},
 	"include": [
+		"ambient.d.ts",
 		"../src/**/*.js",
 		"../src/**/*.ts",
 		"../src/**/*.svelte"
 	],
 	"exclude": [
 		"../node_modules/**",
-		"./**"
+		"./[!ambient.d.ts]**"
 	]
 }

--- a/communityvi-frontend/package-lock.json
+++ b/communityvi-frontend/package-lock.json
@@ -1265,10 +1265,11 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.0.0-next.392",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.392.tgz",
-			"integrity": "sha512-od4rDJ/Soq0I7mda7sTbAnNKERHSDEGNa7QBpLA859xgBkwC1JnEIymYOh9dm+hMyHhB0bUoRoaur0qxKLqOOw==",
+			"version": "1.0.0-next.399",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.399.tgz",
+			"integrity": "sha512-svOZrpfFCkM0sXaPzbGK8YLtbndLzsWPXnUOdf1kwR+MAnoP7txnk7NOfwCScOHkRXMOzWzfeeOcbAHTW1KL0A==",
 			"dev": true,
+			"hasInstallScript": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte": "^1.0.1",
 				"chokidar": "^3.5.3",
@@ -8052,9 +8053,9 @@
 			}
 		},
 		"@sveltejs/kit": {
-			"version": "1.0.0-next.392",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.392.tgz",
-			"integrity": "sha512-od4rDJ/Soq0I7mda7sTbAnNKERHSDEGNa7QBpLA859xgBkwC1JnEIymYOh9dm+hMyHhB0bUoRoaur0qxKLqOOw==",
+			"version": "1.0.0-next.399",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.399.tgz",
+			"integrity": "sha512-svOZrpfFCkM0sXaPzbGK8YLtbndLzsWPXnUOdf1kwR+MAnoP7txnk7NOfwCScOHkRXMOzWzfeeOcbAHTW1KL0A==",
 			"dev": true,
 			"requires": {
 				"@sveltejs/vite-plugin-svelte": "^1.0.1",


### PR DESCRIPTION
I tried this locally and it seems to work..?
It also implicitly migrated the tsconfig.json .