### PR TITLE
Improved bundled file handler

### DIFF
--- a/communityvi-server/src/server.rs
+++ b/communityvi-server/src/server.rs
@@ -74,7 +74,9 @@ fn bundled_frontend_filter() -> BoxedFilter<(Response<Body>,)> {
 	#[folder = "$CARGO_MANIFEST_DIR/../communityvi-frontend/build"]
 	struct FrontendBundle;
 
-	BundledFileHandler::new_with_rust_embed::<FrontendBundle>()
+	BundledFileHandler::builder()
+		.with_rust_embed::<FrontendBundle>()
+		.build()
 		.into_rweb_filter()
 		.boxed()
 }

--- a/communityvi-server/src/server/file_bundle.rs
+++ b/communityvi-server/src/server/file_bundle.rs
@@ -14,38 +14,20 @@ use sha2::{Digest, Sha256};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-
-type FileGetter = Arc<dyn Fn(&str) -> Option<BundledFile> + Send + Sync>;
 
 #[allow(unused)]
 #[derive(Clone)]
 pub struct BundledFileHandler {
-	file_getter: FileGetter,
+	files_by_path: Arc<HashMap<Cow<'static, str>, BundledFile>>,
 }
 
 #[allow(unused)]
 impl BundledFileHandler {
-	/// Creates a new [`BundledFileHandler`] from a [`RustEmbed`] asset type, erasing the type in the process.
-	pub fn new_with_rust_embed<Bundle: RustEmbed>() -> Self {
-		Self {
-			file_getter: Arc::new(|path| Bundle::get(path).map(|file| BundledFile::from_embedded_file(path, file))),
-		}
-	}
-
-	pub fn with_override(self, file: BundledFile) -> Self {
-		let Self { file_getter } = self;
-
-		Self {
-			file_getter: Arc::new(move |path| {
-				if path == file.path {
-					Some(file.clone())
-				} else {
-					file_getter(path)
-				}
-			}),
-		}
+	pub fn builder() -> BundledFileHandlerBuilder {
+		BundledFileHandlerBuilder::default()
 	}
 
 	pub fn into_rweb_filter(self) -> impl Filter<Extract = (Response<Body>,), Error = Infallible> {
@@ -64,49 +46,77 @@ impl BundledFileHandler {
 			return not_modified();
 		}
 
-		file.into_response()
+		file.as_response()
 	}
 
-	fn look_up_file_falling_back_to_index_html(&self, path: &str) -> Option<BundledFile> {
+	fn look_up_file_falling_back_to_index_html(&self, path: &str) -> Option<&BundledFile> {
 		match self.look_up_file(path) {
 			Some(file) => Some(file),
 			None => self.look_up_file(&format!("{path}/index.html")),
 		}
 	}
 
-	fn look_up_file(&self, path: &str) -> Option<BundledFile> {
+	fn look_up_file(&self, path: &str) -> Option<&BundledFile> {
 		let path = normalize_path(path);
-		(self.file_getter)(path)
+		self.files_by_path.get(path)
+	}
+}
+
+#[derive(Default)]
+pub struct BundledFileHandlerBuilder {
+	files_by_path: HashMap<Cow<'static, str>, BundledFile>,
+}
+
+impl BundledFileHandlerBuilder {
+	/// Add files from a [`RustEmbed`] asset type, erasing the type in the process.
+	pub fn with_rust_embed<Bundle: RustEmbed>(mut self) -> Self {
+		self.files_by_path.extend(
+			Bundle::iter()
+				.filter_map(|path| Bundle::get(&path).map(|file| (path, file)))
+				.map(|(path, file)| (path.clone(), BundledFile::from_embedded_file(path, file))),
+		);
+		self
+	}
+
+	pub fn with_file(mut self, file: BundledFile) -> Self {
+		self.files_by_path.insert(file.path.clone(), file);
+		self
+	}
+
+	pub fn build(self) -> BundledFileHandler {
+		BundledFileHandler {
+			files_by_path: Arc::new(self.files_by_path),
+		}
 	}
 }
 
 #[derive(Clone)]
 pub struct BundledFile {
-	path: String,
+	path: Cow<'static, str>,
 	content: Bytes,
 	hash: [u8; 32],
 	last_modified: Option<DateTime<Utc>>,
 }
 
 impl BundledFile {
-	pub fn new(path: &str, content: impl Into<Bytes>) -> Self {
+	pub fn new(path: Cow<'static, str>, content: impl Into<Bytes>) -> Self {
 		let content = content.into();
-		let hash = cached_sha256(path.as_ref(), &content);
+		let hash = cached_sha256(path.deref().as_ref(), &content);
 		Self {
-			path: path.into(),
+			path,
 			content,
 			hash,
 			last_modified: None,
 		}
 	}
 
-	fn from_embedded_file(path: &str, file: EmbeddedFile) -> Self {
+	fn from_embedded_file(path: Cow<'static, str>, file: EmbeddedFile) -> Self {
 		let content = match file.data {
 			Cow::Borrowed(slice) => slice.into(),
 			Cow::Owned(owned) => owned.into(),
 		};
 		Self {
-			path: path.to_string(),
+			path,
 			content,
 			hash: file.metadata.sha256_hash(),
 			last_modified: file
@@ -117,7 +127,7 @@ impl BundledFile {
 		}
 	}
 
-	fn into_response(self) -> Response<Body> {
+	fn as_response(&self) -> Response<Body> {
 		let builder = Response::builder()
 			.status(StatusCode::OK)
 			.header(CONTENT_TYPE, self.mime_type().as_ref())
@@ -133,11 +143,11 @@ impl BundledFile {
 			builder
 		};
 
-		builder.body(Body::from(self.content)).unwrap()
+		builder.body(Body::from(self.content.clone())).unwrap()
 	}
 
 	fn mime_type(&self) -> Mime {
-		MimeGuess::from_path(&self.path).first_or_octet_stream()
+		MimeGuess::from_path(&*self.path).first_or_octet_stream()
 	}
 
 	fn etag(&self) -> String {
@@ -275,7 +285,7 @@ mod test {
 	fn ok_responses_should_contain_the_expected_cache_control_header() {
 		let file = bundled_file("index.html");
 
-		let response = file.into_response();
+		let response = file.as_response();
 		let headers = response.headers();
 
 		assert_eq!("must-revalidate", headers[CACHE_CONTROL]);
@@ -286,7 +296,7 @@ mod test {
 		let file = bundled_file("index.html");
 		let content = file.content.clone();
 
-		let response = file.into_response();
+		let response = file.as_response();
 		let headers = response.headers();
 
 		assert_eq!("text/html", headers[CONTENT_TYPE]);
@@ -298,7 +308,7 @@ mod test {
 		let file = bundled_file("index.html");
 		let etag = file.etag();
 
-		let response = file.into_response();
+		let response = file.as_response();
 		let headers = response.headers();
 
 		assert_eq!(etag.as_bytes(), headers[ETAG].as_bytes());
@@ -308,7 +318,7 @@ mod test {
 	fn ok_responses_should_have_a_last_modified_header() {
 		let file = bundled_file("index.html");
 
-		let response = file.into_response();
+		let response = file.as_response();
 		let headers = response.headers();
 
 		assert!(headers.contains_key(LAST_MODIFIED));
@@ -331,7 +341,7 @@ mod test {
 		let file = bundled_file("index.html");
 		let content = file.content.clone();
 
-		let response = file.into_response();
+		let response = file.as_response();
 
 		assert_eq!(content.as_ref(), response_content(response).await);
 	}
@@ -340,7 +350,7 @@ mod test {
 	fn ok_response_should_have_the_correct_status_code() {
 		let file = bundled_file("index.html");
 
-		let response = file.into_response();
+		let response = file.as_response();
 		let status_code = response.status();
 
 		assert_eq!(StatusCode::OK, status_code);
@@ -398,12 +408,12 @@ mod test {
 	}
 
 	fn test_handler() -> BundledFileHandler {
-		BundledFileHandler::new_with_rust_embed::<TestBundle>()
+		BundledFileHandler::builder().with_rust_embed::<TestBundle>().build()
 	}
 
-	fn bundled_file(path: &str) -> BundledFile {
+	fn bundled_file(path: &'static str) -> BundledFile {
 		let file = TestBundle::get(path).unwrap();
-		BundledFile::from_embedded_file(path, file)
+		BundledFile::from_embedded_file(Cow::Borrowed(path), file)
 	}
 
 	async fn response_content(response: Response<Body>) -> Bytes {

--- a/communityvi-server/src/server/file_bundle.rs
+++ b/communityvi-server/src/server/file_bundle.rs
@@ -266,6 +266,17 @@ mod test {
 		assert_eq!(content.as_ref(), response_content(response).await);
 	}
 
+	#[ignore = "../ in paths is currently unsupported"]
+	#[tokio::test]
+	async fn request_handler_should_work_with_double_dot() {
+		let index = bundled_file("index.html");
+		let content = index.content;
+
+		let response = test_handler().request("foo/../index.html", &HeaderMap::default());
+
+		assert_eq!(content.as_ref(), response_content(response).await);
+	}
+
 	#[test]
 	fn ok_responses_should_contain_the_expected_cache_control_header() {
 		let file = bundled_file("index.html");

--- a/communityvi-server/src/server/rest_api/api_docs.rs
+++ b/communityvi-server/src/server/rest_api/api_docs.rs
@@ -3,14 +3,17 @@ use rust_embed::RustEmbed;
 use rweb::filters::BoxedFilter;
 use rweb::Filter;
 use rweb::Reply;
+use std::borrow::Cow;
 
 pub fn api_docs() -> BoxedFilter<(impl Reply,)> {
 	#[derive(RustEmbed)]
 	#[folder = "$CARGO_MANIFEST_DIR/swagger-ui/node_modules/swagger-ui-dist"]
 	struct SwaggerUi;
 
-	BundledFileHandler::new_with_rust_embed::<SwaggerUi>()
-		.with_override(BundledFile::new("index.html", INDEX_HTML.as_bytes()))
+	BundledFileHandler::builder()
+		.with_rust_embed::<SwaggerUi>()
+		.with_file(BundledFile::new(Cow::Borrowed("index.html"), INDEX_HTML.as_bytes()))
+		.build()
 		.into_rweb_filter()
 		.boxed()
 }

--- a/communityvi-server/src/server/rest_api/api_docs.rs
+++ b/communityvi-server/src/server/rest_api/api_docs.rs
@@ -3,7 +3,6 @@ use rust_embed::RustEmbed;
 use rweb::filters::BoxedFilter;
 use rweb::Filter;
 use rweb::Reply;
-use std::borrow::Cow;
 
 pub fn api_docs() -> BoxedFilter<(impl Reply,)> {
 	#[derive(RustEmbed)]
@@ -11,7 +10,7 @@ pub fn api_docs() -> BoxedFilter<(impl Reply,)> {
 	struct SwaggerUi;
 
 	BundledFileHandler::new_with_rust_embed::<SwaggerUi>()
-		.with_override(BundledFile::new("index.html", Cow::Borrowed(INDEX_HTML.as_bytes())))
+		.with_override(BundledFile::new("index.html", INDEX_HTML.as_bytes()))
 		.into_rweb_filter()
 		.boxed()
 }

--- a/communityvi-server/src/server/rest_api/api_docs.rs
+++ b/communityvi-server/src/server/rest_api/api_docs.rs
@@ -1,4 +1,4 @@
-use crate::server::file_bundle::{BundledFile, BundledFileHandler};
+use crate::server::file_bundle::BundledFileHandler;
 use rust_embed::RustEmbed;
 use rweb::filters::BoxedFilter;
 use rweb::Filter;
@@ -12,7 +12,7 @@ pub fn api_docs() -> BoxedFilter<(impl Reply,)> {
 
 	BundledFileHandler::builder()
 		.with_rust_embed::<SwaggerUi>()
-		.with_file(BundledFile::new(Cow::Borrowed("index.html"), INDEX_HTML.as_bytes()))
+		.with_file(Cow::Borrowed("index.html"), INDEX_HTML)
 		.build()
 		.into_rweb_filter()
 		.boxed()

--- a/communityvi-server/src/server_tests/rest_api.rs
+++ b/communityvi-server/src/server_tests/rest_api.rs
@@ -22,7 +22,7 @@ async fn should_return_reference_time() {
 
 	assert_eq!(response.status(), StatusCode::OK);
 	assert!(reference_time >= uint!(0));
-	assert!(reference_time <= uint!(1_000));
+	assert!(reference_time <= uint!(2_000), "Was {reference_time} ms");
 }
 
 #[tokio::test]


### PR DESCRIPTION
This changes the `BundledFileHandler` from transparently forwarding requests directly to `RustEmbed` to having it's own `HashMap` of files instead.

Notes:
* We now have a startup phase where all the files are iterated over in order to create a `HashMap`.
* The path is stored as `Cow<'static, str>`, so no additional copy is needed for bundled paths.
    * This breaks support for `foo/../my-file.txt`, we can get it back if we need it by normalizing the path though.
    * On the other hand, the way `RustEmbed` supported that was by looping over **all** paths on every lookup and using `std::path::Path`s comparison until one is found (which gets slower the more files you bundle). This is not an issue anymore given that we use a `HashMap`.
* The content is now stored as `Bytes`, which doesn't make a copy in case of `&'static str`, so no additional memory requirements there.
* Adding or overriding files is now just adding an entry to the `HashMap` instead of creating a boxed closure that intercepts the path.
* No SHA256 cache is required anymore, because we can calculate all missing hashes while populating the hashmap.