### PR TITLE
Update to axum 0.6.20

### DIFF
--- a/communityvi-server/Cargo.lock
+++ b/communityvi-server/Cargo.lock
@@ -136,9 +136,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a1de45611fdb535bfde7b7de4fd54f4fd2b17b1737c0a59b69bf9b92074b8c"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -164,7 +164,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tower",
  "tower-layer",
  "tower-service",
@@ -378,7 +378,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.19.0",
  "toml",
  "tower-service",
  "typed-builder",
@@ -1066,9 +1066,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1627,7 +1627,19 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.19.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.20.1",
 ]
 
 [[package]]
@@ -1748,6 +1760,25 @@ name = "tungstenite"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
  "byteorder",
  "bytes",

--- a/communityvi-server/src/connection/sender.rs
+++ b/communityvi-server/src/connection/sender.rs
@@ -59,6 +59,14 @@ impl MessageSender {
 			.map_err(|error| error!("Error while sending `ping`: {:?}", error))
 	}
 
+	pub async fn send_pong(&self, payload: Vec<u8>) -> Result<(), ()> {
+		let mut sink = self.sink.lock().await;
+		let pong = WebSocketMessage::Pong(payload);
+		sink.send(pong)
+			.await
+			.map_err(|error| error!("Error while sending `pong`: {error:?}"))
+	}
+
 	#[allow(let_underscore_drop)] // Ignore Clippy here because we don't care about the result.
 	pub async fn close(&self) {
 		let mut sink = self.sink.lock().await;

--- a/communityvi-server/src/server.rs
+++ b/communityvi-server/src/server.rs
@@ -101,7 +101,6 @@ async fn websocket_handler(
 	State(application_context): State<ApplicationContext>,
 ) -> impl IntoApiResponse {
 	websocket
-		.max_send_queue(1)
 		.max_message_size(10 * 1024)
 		.max_frame_size(10 * 1024)
 		.on_upgrade(move |websocket| run_websocket_connection(websocket, room, application_context))


### PR DESCRIPTION
This fully updates the 0.6 version of `axum` by fixing a test that failed because `axum` updated `tokio-tungstenite` to a version that didn't automatically respond to pings anymore so now we have to do it manually.