### PR TITLE
Move lints from main.rs to Cargo.toml

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Clippy
-        run: cargo clippy --tests
+        run: cargo clippy --tests -- -Dwarnings
   test:
     name: Test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -68,8 +68,6 @@ jobs:
           node-version: 18.x
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "communityvi-server"

--- a/communityvi-server/Cargo.toml
+++ b/communityvi-server/Cargo.toml
@@ -6,6 +6,26 @@ edition = "2021"
 repository = "https://github.com/communityvi/communityvi"
 rust-version = "1.78"
 
+[lints.clippy]
+correctness = { level = "deny", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+style = { level = "warn", priority = -1 }
+suspicious = { level = "warn", priority = -1 }
+complexity = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+
+module_name_repetitions = "allow"
+unseparated_literal_suffix = "allow"
+items_after_statements = "allow"
+default_trait_access = "allow"
+enum_glob_use = "allow"
+wildcard_imports = "allow"
+used_underscore_binding = "allow"
+let_underscore_untyped = "allow"
+multiple_crate_versions = "allow"
+cargo_common_metadata = "allow"
+
+
 [dependencies]
 aide = { version = "0.13", features = ["axum", "axum-ws"] }
 axum = { version = "0.7", features = ["ws", "http2", "macros"] }

--- a/communityvi-server/build.rs
+++ b/communityvi-server/build.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	if !should_bundle_frontend && !should_bundle_stoplight_elements {
 		// don't always rerun build.rs
-		println!("cargo:rerun-if-changed=build.rs")
+		println!("cargo:rerun-if-changed=build.rs");
 	}
 
 	Ok(())

--- a/communityvi-server/src/main.rs
+++ b/communityvi-server/src/main.rs
@@ -1,15 +1,3 @@
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![warn(clippy::cargo)]
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::unseparated_literal_suffix)]
-#![allow(clippy::items_after_statements)]
-#![allow(clippy::multiple_crate_versions)]
-#![allow(clippy::default_trait_access)]
-#![allow(clippy::enum_glob_use)]
-#![allow(clippy::wildcard_imports)]
-#![allow(clippy::used_underscore_binding)]
-#![allow(clippy::let_underscore_untyped)]
 use crate::commandline::Commandline;
 use crate::error::CommunityviError;
 use clap::Parser;

--- a/communityvi-server/src/message/client_request.rs
+++ b/communityvi-server/src/message/client_request.rs
@@ -39,6 +39,7 @@ impl ClientRequest {
 	}
 }
 
+#[allow(dead_code)]
 trait RequestConvertible: Into<ClientRequest> {
 	fn with_id(self, request_id: UInt) -> ClientRequestWithId {
 		ClientRequestWithId {


### PR DESCRIPTION
Moves the lints to Cargo.toml from the code.

Also reduces `deny` to `warn` so lints are only warnings locally, but still deny them in CI.