### PR TITLE
Remove vitest-dom

### DIFF
--- a/communityvi-frontend/package-lock.json
+++ b/communityvi-frontend/package-lock.json
@@ -36,7 +36,6 @@
 				"typescript": "^5.0.0",
 				"vite": "^5.0.0",
 				"vitest": "^2.0.0",
-				"vitest-dom": "^0.1.1",
 				"vitest-mock-extended": "^2.0.0"
 			}
 		},
@@ -2379,13 +2378,6 @@
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
-		"node_modules/css.escape": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3281,19 +3273,6 @@
 				"node": ">=0.8.19"
 			}
 		},
-		"node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3618,13 +3597,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
@@ -4304,39 +4276,6 @@
 			"funding": {
 				"type": "individual",
 				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/redent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-			"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"indent-string": "^5.0.0",
-				"strip-indent": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/redent/node_modules/strip-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-			"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"min-indent": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/regenerator-runtime": {
@@ -5444,44 +5383,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/vitest-dom": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/vitest-dom/-/vitest-dom-0.1.1.tgz",
-			"integrity": "sha512-n/bonR2hcRHCE5hlzG/P0yTXTUXx/gPtsaeUWP86ADfwo/+dHDpnTTV14qY7+kevsUbOZFYECu77MXY7AA0QSA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"aria-query": "^5.3.0",
-				"chalk": "^5.3.0",
-				"css.escape": "^1.5.1",
-				"dom-accessibility-api": "^0.6.1",
-				"lodash-es": "^4.17.21",
-				"redent": "^4.0.0"
-			},
-			"peerDependencies": {
-				"vitest": ">=0.31.0"
-			}
-		},
-		"node_modules/vitest-dom/node_modules/chalk": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-			"integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/vitest-dom/node_modules/dom-accessibility-api": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-			"integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/vitest-mock-extended": {
 			"version": "2.0.2",

--- a/communityvi-frontend/package.json
+++ b/communityvi-frontend/package.json
@@ -43,7 +43,6 @@
 		"typescript": "^5.0.0",
 		"vite": "^5.0.0",
 		"vitest": "^2.0.0",
-		"vitest-dom": "^0.1.1",
 		"vitest-mock-extended": "^2.0.0"
 	}
 }

--- a/communityvi-frontend/tests/components/hello.spec.ts
+++ b/communityvi-frontend/tests/components/hello.spec.ts
@@ -1,18 +1,14 @@
 import Hello from '$lib/components/Hello.svelte';
 import {render} from '@testing-library/svelte';
-import 'vitest-dom/extend-expect';
-import * as matchers from 'vitest-dom/matchers';
 import {describe, it, expect} from 'vitest';
-
-expect.extend(matchers);
 
 describe('The Hello component', () => {
 	it('inserts the passed name into the output', async () => {
 		const name = 'Max';
 
 		const renderedComponent = render(Hello, {name});
-		const output = await renderedComponent.findByText('Hello Max!');
+		const outputHtml = (await renderedComponent.findByText('Hello Max!')).innerHTML;
 
-		expect(output).toHaveTextContent('Hello Max!');
+		expect(outputHtml).toContain('Hello Max!');
 	});
 });


### PR DESCRIPTION
It's not maintained anymore and reintroducing jest-dom doesn't seem worth it given the pain of upgrading these kinds of dependencies and that we are only using it once.