### PR TITLE
Update all backend dependencies except axum

### DIFF
--- a/communityvi-server/Cargo.lock
+++ b/communityvi-server/Cargo.lock
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
+checksum = "c94feba04f99cbce6558bbe1c18e38692a056981cb66c96f0878c2452aa28023"
 dependencies = [
  "memchr",
  "serde",
@@ -1304,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773ce68d0bb9bc7ef20be3536ffe94e223e1f365bd374108b2659fac0c65cfe6"
+checksum = "3bd1fe6824cea6538803de3ff1bc0cf3949024db3d43c9643024bfb33a807c0e"
 dependencies = [
  "crossbeam-utils",
  "libc",
@@ -1715,9 +1715,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.93"
+version = "2.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
+checksum = "987bc0be1cdea8b10216bd06e2ca407d40b9543468fafd3ddfb02f36e77f71f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2470,9 +2470,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "e6f5bb5257f2407a5425c6e749bfd9692192a73e70a6060516ac04f889087d68"
 dependencies = [
  "memchr",
 ]

--- a/communityvi-server/Cargo.lock
+++ b/communityvi-server/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -405,7 +405,7 @@ dependencies = [
  "thiserror 2.0.9",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.1",
  "toml",
  "tower-http",
  "tower-service",
@@ -1857,7 +1857,19 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4bf6fecd69fcdede0ec680aaf474cdab988f9de6bc73d3758f0160e3b7025a"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.26.1",
 ]
 
 [[package]]
@@ -2017,6 +2029,24 @@ dependencies = [
  "rand",
  "sha1",
  "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413083a99c579593656008130e29255e54dcaae495be556cc26888f211648c24"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 2.0.9",
  "utf-8",
 ]
 

--- a/communityvi-server/Cargo.lock
+++ b/communityvi-server/Cargo.lock
@@ -698,13 +698,14 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+checksum = "842dc78579ce01e6a1576ad896edc92fca002dd60c9c3746b7fc2bec6fb429d0"
 dependencies = [
  "cfg-if",
- "futures",
+ "futures-sink",
  "futures-timer",
+ "futures-util",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",

--- a/communityvi-server/Cargo.toml
+++ b/communityvi-server/Cargo.toml
@@ -35,8 +35,8 @@ chrono = { version = "0.4", default-features = false, features = ["std", "clock"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
 futures-util = "0.3"
-futures-channel = "0.3"
-governor = { version = "0.6", default-features = false, features = ["std", "jitter"] }
+futures-channel = { version = "0.3", features = ["sink"] }
+governor = { version = "0.8", default-features = false, features = ["std", "jitter"] }
 hex = "0.4"
 humantime-serde = "1"
 http-body-util = "0.1"

--- a/communityvi-server/Cargo.toml
+++ b/communityvi-server/Cargo.toml
@@ -55,7 +55,7 @@ sha2 = "0.10"
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "parking_lot", "macros", "sync"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["sync"] }
-tokio-tungstenite = "0.24"
+tokio-tungstenite = "0.26"
 toml = "0.8"
 tower-http = { version = "0.6", features = ["cors"] }
 tower-service = "0.3"

--- a/communityvi-server/src/connection/receiver.rs
+++ b/communityvi-server/src/connection/receiver.rs
@@ -35,7 +35,7 @@ impl MessageReceiver {
 						// respond to ping in-place. Previously, tungstenite did this for us, but now we need to
 						// to it manually and keep on looping until we receive a non-ping message
 						// TODO: Put this responding into a more appropriate place
-						if let Err(()) = self.sender.send_pong(payload).await {
+						if let Err(()) = self.sender.send_pong(payload.into()).await {
 							return Finished;
 						}
 					}
@@ -49,7 +49,11 @@ impl MessageReceiver {
 			};
 
 			let websocket_message = match websocket_message {
-				Pong(payload) => return ReceivedMessage::Pong { payload },
+				Pong(payload) => {
+					return ReceivedMessage::Pong {
+						payload: payload.to_vec(),
+					}
+				}
 				Close(_) => {
 					self.sender.close().await;
 					return Finished;

--- a/communityvi-server/src/connection/sender.rs
+++ b/communityvi-server/src/connection/sender.rs
@@ -53,7 +53,7 @@ impl MessageSender {
 
 	pub async fn send_ping(&self, payload: Vec<u8>) -> Result<(), ()> {
 		let mut sink = self.sink.lock().await;
-		let ping = WebSocketMessage::Ping(payload);
+		let ping = WebSocketMessage::Ping(payload.into());
 		sink.send(ping)
 			.await
 			.map_err(|error| error!("Error while sending `ping`: {:?}", error))
@@ -61,7 +61,7 @@ impl MessageSender {
 
 	pub async fn send_pong(&self, payload: Vec<u8>) -> Result<(), ()> {
 		let mut sink = self.sink.lock().await;
-		let pong = WebSocketMessage::Pong(payload);
+		let pong = WebSocketMessage::Pong(payload.into());
 		sink.send(pong)
 			.await
 			.map_err(|error| error!("Error while sending `pong`: {error:?}"))

--- a/communityvi-server/src/utils/test_client.rs
+++ b/communityvi-server/src/utils/test_client.rs
@@ -108,7 +108,7 @@ impl WebsocketTestClient {
 
 	pub async fn receive_ping(&mut self) -> Vec<u8> {
 		if let WebSocketMessage::Ping(payload) = self.receive_raw().await {
-			payload
+			payload.to_vec()
 		} else {
 			panic!("Invalid raw message received.");
 		}

--- a/communityvi-server/src/utils/websocket_message_conversion.rs
+++ b/communityvi-server/src/utils/websocket_message_conversion.rs
@@ -1,20 +1,25 @@
 use anyhow::bail;
+use std::borrow::Cow;
 use tokio_tungstenite::tungstenite;
 use tokio_tungstenite::tungstenite::protocol::CloseFrame;
+use tokio_tungstenite::tungstenite::Utf8Bytes;
 
 pub fn axum_websocket_message_to_tungstenite_message(axum_message: axum::extract::ws::Message) -> tungstenite::Message {
 	use axum::extract::ws::CloseFrame;
 	use axum::extract::ws::Message::*;
 
 	match axum_message {
-		Text(text) => tungstenite::Message::Text(text),
-		Binary(data) => tungstenite::Message::Binary(data),
-		Ping(data) => tungstenite::Message::Ping(data),
-		Pong(data) => tungstenite::Message::Pong(data),
+		Text(text) => tungstenite::Message::Text(text.into()),
+		Binary(data) => tungstenite::Message::Binary(data.into()),
+		Ping(data) => tungstenite::Message::Ping(data.into()),
+		Pong(data) => tungstenite::Message::Pong(data.into()),
 		Close(Some(CloseFrame { code, reason })) => {
 			tungstenite::Message::Close(Some(tungstenite::protocol::CloseFrame {
 				code: code.into(),
-				reason,
+				reason: match reason {
+					Cow::Borrowed(reason) => Utf8Bytes::from_static(reason),
+					Cow::Owned(reason) => reason.into(),
+				},
 			}))
 		}
 		Close(None) => tungstenite::Message::Close(None),
@@ -28,13 +33,13 @@ pub fn tungstenite_message_to_axum_websocket_message(
 	use tungstenite::Message::*;
 
 	Ok(match tungstenite_message {
-		Text(text) => ws::Message::Text(text),
-		Binary(data) => ws::Message::Binary(data),
-		Ping(data) => ws::Message::Ping(data),
-		Pong(data) => ws::Message::Pong(data),
+		Text(text) => ws::Message::Text(text.as_str().to_owned()),
+		Binary(data) => ws::Message::Binary(data.into()),
+		Ping(data) => ws::Message::Ping(data.into()),
+		Pong(data) => ws::Message::Pong(data.into()),
 		Close(Some(CloseFrame { code, reason })) => ws::Message::Close(Some(ws::CloseFrame {
 			code: code.into(),
-			reason,
+			reason: reason.as_str().to_owned().into(),
 		})),
 		Close(None) => ws::Message::Close(None),
 		Frame(_frame) => bail!("Websocket frames are not supported by axum at the moment"),


### PR DESCRIPTION
Tokio tungstenite changed it's types from `String` and `Vec<u8>` to `Utf8Bytes` and `Bytes`. Easy to fix by just converting. Although it does affect our error message strings, which is mostly a testament to bad error messages on our part.

Updating governor broke some unrelated stuff, but this ultimately came down to missing a required feature for `futures-channel` which no longer gets pulled in transitively.