### PR TITLE
UX fix: Focus text input after chat message was sent

### DIFF
--- a/communityvi-frontend/src/lib/components/chat/ChatInput.svelte
+++ b/communityvi-frontend/src/lib/components/chat/ChatInput.svelte
@@ -9,6 +9,8 @@
 	let message = $state('');
 	let isMessageEmpty = $derived(message.trim().length === 0);
 
+	let textInput: HTMLInputElement | undefined = $state(undefined);
+
 	async function sendChatMessage() {
 		if ($registeredClient === undefined) {
 			return;
@@ -20,6 +22,8 @@
 			message = '';
 			await $registeredClient.sendChatMessage(messageToSend);
 			dispatch('chatMessageAcknowledged', messageToSend);
+
+			textInput?.focus();
 		} catch (error) {
 			console.error('Error while sending chat message:', error);
 			notifications.reportError(new Error('Chat message sending failed!'));
@@ -30,6 +34,6 @@
 </script>
 
 <form onsubmit={preventDefault(sendChatMessage)}>
-	<input type="text" bind:value={message} disabled={isNotRegistered || undefined} />
+	<input type="text" bind:this={textInput} bind:value={message} disabled={isNotRegistered || undefined} />
 	<input type="submit" value="Send" disabled={isNotRegistered || isMessageEmpty || undefined} />
 </form>

--- a/communityvi-frontend/src/lib/components/player/Player.svelte
+++ b/communityvi-frontend/src/lib/components/player/Player.svelte
@@ -6,7 +6,7 @@
 
 	// NOTE: currentTime needs to be accessed via the player itself because the binding provided by svelte
 	// as of 3.38.3 neither reads the currentTime reliably, nor sets it reliably.
-	let player: HTMLVideoElement | null | undefined = $state();
+	let player: HTMLVideoElement | undefined = $state(undefined);
 
 	// NOTE: Reactively act on registeredClient (e.g. reconnect) and videoUrl (e.g. local medium selection)
 	// changed to catch all cases in which the player or its position require updating.


### PR DESCRIPTION
This allows sending multiple chat messages in quick succession without having to manually reenter the input field after every single message that was sent.