### PR TITLE
Turn reference time into UNIX timestamp without loosing monotonicity

### DIFF
--- a/communityvi-server/src/lifecycle.rs
+++ b/communityvi-server/src/lifecycle.rs
@@ -370,6 +370,7 @@ mod test {
 	use crate::room::session_id::SessionId;
 	use crate::utils::fake_message_sender::FakeMessageSender;
 	use crate::utils::test_client::WebsocketTestClient;
+	use chrono::DateTime;
 	use js_int::{int, uint};
 
 	#[tokio::test]
@@ -476,7 +477,7 @@ mod test {
 
 	#[tokio::test]
 	async fn the_client_should_be_able_to_play_the_inserted_medium() {
-		let room = Room::new(ReferenceTimer::default(), 2);
+		let room = Room::new(ReferenceTimer::default().with_start_time(DateTime::UNIX_EPOCH), 2);
 		let (alice, mut alice_test_client) = WebsocketTestClient::in_room("Alice", &room);
 		let (_bob, mut bob_test_client) = WebsocketTestClient::in_room("Bob", &room);
 
@@ -822,7 +823,7 @@ mod test {
 
 	#[tokio::test]
 	async fn should_get_currently_playing_medium_on_hello_response() {
-		let reference_timer = ReferenceTimer::default();
+		let reference_timer = ReferenceTimer::default().with_start_time(DateTime::UNIX_EPOCH);
 		let room = Room::new(reference_timer, 1);
 		let video_name = "Short Circuit".to_string();
 		let video_length = Duration::minutes(98);

--- a/communityvi-server/src/reference_time.rs
+++ b/communityvi-server/src/reference_time.rs
@@ -91,4 +91,21 @@ mod test {
 			"Expected the elapsed time to be between 1ms, but was: {elapsed}ms",
 		);
 	}
+
+	#[test]
+	fn reference_time_should_resemble_unix_timestamp() {
+		let reference_timer = ReferenceTimer::default();
+		let now = Utc::now();
+
+		let reference_time = reference_timer.reference_time_milliseconds();
+
+		let unix_timestamp = now.timestamp_millis();
+		let reference_timestamp = i64::from(reference_time);
+
+		let diff = (unix_timestamp - reference_timestamp).abs();
+		assert!(
+			diff < 100,
+			"The reference time wasn't close enough to a UNIX timestamp. Diff: {diff} ms"
+		);
+	}
 }

--- a/communityvi-server/src/server_tests/rest_api.rs
+++ b/communityvi-server/src/server_tests/rest_api.rs
@@ -1,6 +1,7 @@
+use crate::reference_time::ReferenceTimer;
 use crate::server_tests::start_test_server;
 use axum::http::StatusCode;
-use js_int::{UInt, uint};
+use js_int::UInt;
 use serde::Deserialize;
 
 #[cfg(feature = "api-docs")]
@@ -8,6 +9,7 @@ mod api_docs;
 
 #[tokio::test]
 async fn should_return_reference_time() {
+	let reference_timer = ReferenceTimer::default();
 	let client = start_test_server().await;
 	let response = client
 		.get("/api/reference-time-milliseconds")
@@ -21,9 +23,12 @@ async fn should_return_reference_time() {
 		.await
 		.expect("Failed to parse reference time response");
 
+	let reference_time = i64::from(reference_time);
+	let expected_reference_time = i64::from(reference_timer.reference_time_milliseconds());
+	let diff = (reference_time - expected_reference_time).abs();
 	assert_eq!(status, StatusCode::OK);
-	assert!(reference_time >= uint!(0));
-	assert!(reference_time <= uint!(2_000), "Was {reference_time} ms");
+	assert!(diff >= 0);
+	assert!(diff <= 2_000, "Was {diff} ms");
 }
 
 #[tokio::test]


### PR DESCRIPTION
This anchors the reference time in the UNIX timestamp by recording when the reference timer was created and adding the unix timestamp from that offset back to the reference time.

This means that the reference time can be stored in an external database and persist across server restarts.